### PR TITLE
Add `ChromeAI`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ node_modules
 **/package.json
 !/package.json
 jupyterlite_ai
+.venv

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Enable the proper flags in Google Chrome.
 
 Then restart Chrome for these changes to take effect.
 
+You can test ChromeAI is enabled in your browser by going to the following URL: https://chromeai.org/
+
 > [!WARNING]
 > On first use, Chrome will download the on-device model, which can be as large as 22GB (according to their docs and at the time of writing).
 > During the download, ChromeAI may not be available via the extension.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ The process is different for each provider, so you may refer to their documentat
 
 ![Screenshot showing how to use the chat](./img/3-usage.png)
 
+## Using ChromeAI
+
+> [!WARNING]
+> Support for ChromeAI is still experimental.
+
+Enable the proper flags in Google Chrome.
+
+- chrome://flags/#prompt-api-for-gemini-nano
+- [Optional] chrome://flags/#text-safety-classifier
+
+![a screenshot showing how to enable the ChromeAI flag in Google Chrome](https://github.com/user-attachments/assets/d48f46cc-52ee-4ce5-9eaf-c763cdbee04c)
+
+Then restart Chrome for these changes to take effect.
+
+> [!WARNING]
+> On first use, Chrome will download the on-device model, which can be as large as 22GB (according to their docs).
+> During the download, ChromeAI may not be available via the extension.
+
+> [!NOTE]
+> For more information about Chrome Built-in AI: https://developer.chrome.com/docs/ai/get-started
+
 ## Uninstall
 
 To remove the extension, execute:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The process is different for each provider, so you may refer to their documentat
 ## Using ChromeAI
 
 > [!WARNING]
-> Support for ChromeAI is still experimental.
+> Support for ChromeAI is still experimental and only available in Google Chrome.
 
 Enable the proper flags in Google Chrome.
 
@@ -77,7 +77,7 @@ Enable the proper flags in Google Chrome.
 Then restart Chrome for these changes to take effect.
 
 > [!WARNING]
-> On first use, Chrome will download the on-device model, which can be as large as 22GB (according to their docs).
+> On first use, Chrome will download the on-device model, which can be as large as 22GB (according to their docs and at the time of writing).
 > During the download, ChromeAI may not be available via the extension.
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -67,16 +67,21 @@ The process is different for each provider, so you may refer to their documentat
 > [!WARNING]
 > Support for ChromeAI is still experimental and only available in Google Chrome.
 
+You can test ChromeAI is enabled in your browser by going to the following URL: https://chromeai.org/
+
 Enable the proper flags in Google Chrome.
 
 - chrome://flags/#prompt-api-for-gemini-nano
+  - Select: `Enabled`
+- chrome://flags/#optimization-guide-on-device-model
+  - Select: `Enabled BypassPrefRequirement`
+- chrome://components
+  - Click `Check for Update` on Optimization Guide On Device Model to download the model
 - [Optional] chrome://flags/#text-safety-classifier
 
 ![a screenshot showing how to enable the ChromeAI flag in Google Chrome](https://github.com/user-attachments/assets/d48f46cc-52ee-4ce5-9eaf-c763cdbee04c)
 
 Then restart Chrome for these changes to take effect.
-
-You can test ChromeAI is enabled in your browser by going to the following URL: https://chromeai.org/
 
 > [!WARNING]
 > On first use, Chrome will download the on-device model, which can be as large as 22GB (according to their docs and at the time of writing).

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "@jupyterlab/rendermime": "^4.4.0-alpha.0",
         "@jupyterlab/settingregistry": "^4.4.0-alpha.0",
         "@langchain/anthropic": "^0.3.9",
+        "@langchain/community": "^0.3.26",
         "@langchain/core": "^0.3.13",
         "@langchain/mistralai": "^0.1.1",
         "@lumino/coreutils": "^2.1.2",

--- a/schema/ai-provider.json
+++ b/schema/ai-provider.json
@@ -8,7 +8,7 @@
       "title": "The AI provider",
       "description": "The AI provider to use for chat and completion",
       "default": "None",
-      "enum": ["None", "Anthropic", "MistralAI"]
+      "enum": ["None", "Anthropic", "ChromeAI", "MistralAI"]
     }
   },
   "additionalProperties": true

--- a/scripts/settings-generator.js
+++ b/scripts/settings-generator.js
@@ -33,7 +33,7 @@ const schemaBase = tsj
 const providers = {
   chromeAI: {
     path: 'node_modules/@langchain/community/experimental/llms/chrome_ai.d.ts',
-    type: 'ChromeAIInputs',
+    type: 'ChromeAIInputs'
   },
   mistralAI: {
     path: 'node_modules/@langchain/mistralai/dist/chat_models.d.ts',

--- a/scripts/settings-generator.js
+++ b/scripts/settings-generator.js
@@ -31,6 +31,10 @@ const schemaBase = tsj
  *     to exclude them at the moment, to be able to build other settings.
  */
 const providers = {
+  chromeAI: {
+    path: 'node_modules/@langchain/community/experimental/llms/chrome_ai.d.ts',
+    type: 'ChromeAI'
+  },
   mistralAI: {
     path: 'node_modules/@langchain/mistralai/dist/chat_models.d.ts',
     type: 'ChatMistralAIInput'
@@ -78,6 +82,21 @@ Object.entries(providers).forEach(([name, desc], index) => {
 
   // Remove the properties from extended class.
   const providerKeys = Object.keys(schema.definitions[desc.type]['properties']);
+
+  // TODO: fix for ChromeAI
+  const keys = [
+    'ParsedCallOptions',
+    'lc_kwargs',
+    'lc_namespace',
+    'lc_serializable',
+    'caller'
+  ];
+  keys.forEach(key => {
+    if (providerKeys.includes(key)) {
+      delete schema.definitions?.[desc.type]['properties'][key];
+    }
+  });
+
   Object.keys(
     schemaBase.definitions?.['BaseLanguageModelParams']['properties']
   ).forEach(key => {

--- a/scripts/settings-generator.js
+++ b/scripts/settings-generator.js
@@ -33,7 +33,7 @@ const schemaBase = tsj
 const providers = {
   chromeAI: {
     path: 'node_modules/@langchain/community/experimental/llms/chrome_ai.d.ts',
-    type: 'ChromeAI'
+    type: 'ChromeAIInputs',
   },
   mistralAI: {
     path: 'node_modules/@langchain/mistralai/dist/chat_models.d.ts',
@@ -82,20 +82,6 @@ Object.entries(providers).forEach(([name, desc], index) => {
 
   // Remove the properties from extended class.
   const providerKeys = Object.keys(schema.definitions[desc.type]['properties']);
-
-  // TODO: fix for ChromeAI
-  const keys = [
-    'ParsedCallOptions',
-    'lc_kwargs',
-    'lc_namespace',
-    'lc_serializable',
-    'caller'
-  ];
-  keys.forEach(key => {
-    if (providerKeys.includes(key)) {
-      delete schema.definitions?.[desc.type]['properties'][key];
-    }
-  });
 
   Object.keys(
     schemaBase.definitions?.['BaseLanguageModelParams']['properties']

--- a/src/chat-handler.ts
+++ b/src/chat-handler.ts
@@ -91,7 +91,9 @@ export class ChatHandler extends ChatModel {
     return this._aiProvider.chatModel
       .invoke(messages)
       .then(response => {
-        const content = response.content;
+        // Some providers may use text-completion models (for example ChromeAI),
+        // for which the response is a string.
+        const content = response.content ?? response;
         const botMsg: IChatMessage = {
           id: UUID.uuid4(),
           body: content.toString(),

--- a/src/llm-models/chrome-completer.ts
+++ b/src/llm-models/chrome-completer.ts
@@ -4,11 +4,20 @@ import {
 } from '@jupyterlab/completer';
 import { ChromeAI } from '@langchain/community/experimental/llms/chrome_ai';
 import { LLM } from '@langchain/core/language_models/llms';
-
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { BaseCompleter, IBaseCompleter } from './base-completer';
-
 import { COMPLETION_SYSTEM_PROMPT } from '../provider';
+
+/**
+ * The initial prompt to use for the completion.
+ * Add extra instructions to get better results.
+ */
+const CUSTOM_SYSTEM_PROMPT = `${COMPLETION_SYSTEM_PROMPT}
+Only give raw strings back, do not format the response using backticks!
+The output should be a single string, and should correspond to what a human users
+would write.
+Do not include the prompt in the output, only the string that should be appended to the current input.
+`;
 
 export class ChromeCompleter implements IBaseCompleter {
   constructor(options: BaseCompleter.IOptions) {
@@ -67,5 +76,5 @@ export class ChromeCompleter implements IBaseCompleter {
   }
 
   private _chromeProvider: ChromeAI;
-  private _prompt: string = COMPLETION_SYSTEM_PROMPT;
+  private _prompt: string = CUSTOM_SYSTEM_PROMPT;
 }

--- a/src/llm-models/chrome-completer.ts
+++ b/src/llm-models/chrome-completer.ts
@@ -57,12 +57,8 @@ export class ChromeCompleter implements IBaseCompleter {
       const response = await this._chromeProvider.invoke(messages);
 
       if (response.startsWith('```')) {
-        console.log('Skipping response that includes code block');
         return { items: [] };
       }
-
-      console.log('input:', trimmedPrompt);
-      console.log('response:', response);
 
       const items = [{ insertText: response }];
       return {

--- a/src/llm-models/chrome-completer.ts
+++ b/src/llm-models/chrome-completer.ts
@@ -44,7 +44,6 @@ export class ChromeCompleter implements IBaseCompleter {
   ) {
     const { text, offset: cursorOffset } = request;
     const prompt = text.slice(0, cursorOffset);
-    // const suffix = text.slice(cursorOffset);
 
     const trimmedPrompt = prompt.trim();
 

--- a/src/llm-models/chrome-completer.ts
+++ b/src/llm-models/chrome-completer.ts
@@ -8,26 +8,21 @@ import { LLM } from '@langchain/core/language_models/llms';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { BaseCompleter, IBaseCompleter } from './base-completer';
 
-/**
- * The default prompt for the completion request
- * TODO: move somewhere else so it can be used by other completers
- * See: https://github.com/jupyterlite/ai/issues/25
- */
-const DEFAULT_PROMPT = `
-You are an application built to provide helpful code completion suggestions.
-You should only produce code. Produce clean code.
-The code is written in JupyterLab, a data analysis and code development
-environment which can execute code extended with additional syntax for
-interactive features, such as magics.
-Only give raw strings back, do not format the response using backticks!
-The output should be a single string, and should correspond to what a human users
-would write.
-Do not include the prompt in the output, only the string that should be appended to the current input.
-`;
+import { COMPLETION_SYSTEM_PROMPT } from '../provider';
 
 export class ChromeCompleter implements IBaseCompleter {
   constructor(options: BaseCompleter.IOptions) {
     this._chromeProvider = new ChromeAI({ ...options.settings });
+  }
+
+  /**
+   * Getter and setter for the initial prompt.
+   */
+  get prompt(): string {
+    return this._prompt;
+  }
+  set prompt(value: string) {
+    this._prompt = value;
   }
 
   get provider(): LLM {
@@ -46,7 +41,7 @@ export class ChromeCompleter implements IBaseCompleter {
 
     // TODO: this should include more messages
     const messages = [
-      new SystemMessage(DEFAULT_PROMPT),
+      new SystemMessage(this._prompt),
       new HumanMessage(trimmedPrompt)
     ];
 
@@ -72,4 +67,5 @@ export class ChromeCompleter implements IBaseCompleter {
   }
 
   private _chromeProvider: ChromeAI;
+  private _prompt: string = COMPLETION_SYSTEM_PROMPT;
 }

--- a/src/llm-models/chrome-completer.ts
+++ b/src/llm-models/chrome-completer.ts
@@ -48,7 +48,6 @@ export class ChromeCompleter implements IBaseCompleter {
 
     const trimmedPrompt = prompt.trim();
 
-    // TODO: this should include more messages
     const messages = [
       new SystemMessage(this._prompt),
       new HumanMessage(trimmedPrompt)

--- a/src/llm-models/chrome-completer.ts
+++ b/src/llm-models/chrome-completer.ts
@@ -1,0 +1,75 @@
+import {
+  CompletionHandler,
+  IInlineCompletionContext
+} from '@jupyterlab/completer';
+import { ChromeAI } from '@langchain/community/experimental/llms/chrome_ai';
+import { LLM } from '@langchain/core/language_models/llms';
+
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { BaseCompleter, IBaseCompleter } from './base-completer';
+
+/**
+ * The default prompt for the completion request
+ * TODO: move somewhere else so it can be used by other completers
+ * See: https://github.com/jupyterlite/ai/issues/25
+ */
+const DEFAULT_PROMPT = `
+You are an application built to provide helpful code completion suggestions.
+You should only produce code. Produce clean code.
+The code is written in JupyterLab, a data analysis and code development
+environment which can execute code extended with additional syntax for
+interactive features, such as magics.
+Only give raw strings back, do not format the response using backticks!
+The output should be a single string, and should correspond to what a human users
+would write.
+Do not include the prompt in the output, only the string that should be appended to the current input.
+`;
+
+export class ChromeCompleter implements IBaseCompleter {
+  constructor(options: BaseCompleter.IOptions) {
+    this._chromeProvider = new ChromeAI({ ...options.settings });
+  }
+
+  get provider(): LLM {
+    return this._chromeProvider;
+  }
+
+  async fetch(
+    request: CompletionHandler.IRequest,
+    context: IInlineCompletionContext
+  ) {
+    const { text, offset: cursorOffset } = request;
+    const prompt = text.slice(0, cursorOffset);
+    // const suffix = text.slice(cursorOffset);
+
+    const trimmedPrompt = prompt.trim();
+
+    // TODO: this should include more messages
+    const messages = [
+      new SystemMessage(DEFAULT_PROMPT),
+      new HumanMessage(trimmedPrompt)
+    ];
+
+    try {
+      const response = await this._chromeProvider.invoke(messages);
+
+      if (response.startsWith('```')) {
+        console.log('Skipping response that includes code block');
+        return { items: [] };
+      }
+
+      console.log('input:', trimmedPrompt);
+      console.log('response:', response);
+
+      const items = [{ insertText: response }];
+      return {
+        items
+      };
+    } catch (error) {
+      console.error('Error fetching completion:', error);
+      return { items: [] };
+    }
+  }
+
+  private _chromeProvider: ChromeAI;
+}

--- a/src/llm-models/chrome-completer.ts
+++ b/src/llm-models/chrome-completer.ts
@@ -55,6 +55,8 @@ export class ChromeCompleter implements IBaseCompleter {
     try {
       const response = await this._chromeProvider.invoke(messages);
 
+      // ChromeAI sometimes returns a string starting with '```', which
+      // is not great for completing text, so ignore it
       if (response.startsWith('```')) {
         return { items: [] };
       }

--- a/src/llm-models/utils.ts
+++ b/src/llm-models/utils.ts
@@ -73,7 +73,7 @@ export function getSettings(name: string): JSONObject | null {
   } else if (name === 'Anthropic') {
     return anthropic.definitions.AnthropicInput.properties;
   } else if (name === 'ChromeAI') {
-    return chromeAI.definitions.ChromeAI.properties;
+    return chromeAI.definitions.ChromeAIInputs.properties;
   }
 
   return null;

--- a/src/llm-models/utils.ts
+++ b/src/llm-models/utils.ts
@@ -1,4 +1,5 @@
 import { ChatAnthropic } from '@langchain/anthropic';
+import { ChromeAI } from '@langchain/community/experimental/llms/chrome_ai';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { ChatMistralAI } from '@langchain/mistralai';
 import { JSONObject } from '@lumino/coreutils';
@@ -7,7 +8,9 @@ import { IBaseCompleter } from './base-completer';
 import { AnthropicCompleter } from './anthropic-completer';
 import { CodestralCompleter } from './codestral-completer';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
+import { ChromeCompleter } from './chrome-completer';
 
+import chromeAI from '../_provider-settings/chromeAI.json';
 import mistralAI from '../_provider-settings/mistralAI.json';
 import anthropic from '../_provider-settings/anthropic.json';
 
@@ -22,6 +25,8 @@ export function getCompleter(
     return new CodestralCompleter({ settings });
   } else if (name === 'Anthropic') {
     return new AnthropicCompleter({ settings });
+  } else if (name === 'ChromeAI') {
+    return new ChromeCompleter({ settings });
   }
   return null;
 }
@@ -37,6 +42,10 @@ export function getChatModel(
     return new ChatMistralAI({ ...settings });
   } else if (name === 'Anthropic') {
     return new ChatAnthropic({ ...settings });
+  } else if (name === 'ChromeAI') {
+    // TODO: fix
+    // @ts-expect-error
+    return new ChromeAI({ ...settings });
   }
   return null;
 }
@@ -49,6 +58,8 @@ export function getErrorMessage(name: string, error: any): string {
     return error.message;
   } else if (name === 'Anthropic') {
     return error.error.error.message;
+  } else if (name === 'ChromeAI') {
+    return error.message;
   }
   return 'Unknown provider';
 }
@@ -61,6 +72,9 @@ export function getSettings(name: string): JSONObject | null {
     return mistralAI.definitions.ChatMistralAIInput.properties;
   } else if (name === 'Anthropic') {
     return anthropic.definitions.AnthropicInput.properties;
+  } else if (name === 'ChromeAI') {
+    return chromeAI.definitions.ChromeAI.properties;
   }
+
   return null;
 }

--- a/src/llm-models/utils.ts
+++ b/src/llm-models/utils.ts
@@ -44,7 +44,7 @@ export function getChatModel(
     return new ChatAnthropic({ ...settings });
   } else if (name === 'ChromeAI') {
     // TODO: fix
-    // @ts-expect-error
+    // @ts-expect-error: missing properties
     return new ChromeAI({ ...settings });
   }
   return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,6 +1959,7 @@ __metadata:
     "@jupyterlab/rendermime": ^4.4.0-alpha.0
     "@jupyterlab/settingregistry": ^4.4.0-alpha.0
     "@langchain/anthropic": ^0.3.9
+    "@langchain/community": ^0.3.26
     "@langchain/core": ^0.3.13
     "@langchain/mistralai": ^0.1.1
     "@lumino/coreutils": ^2.1.2
@@ -2003,6 +2004,394 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@langchain/community@npm:^0.3.26":
+  version: 0.3.26
+  resolution: "@langchain/community@npm:0.3.26"
+  dependencies:
+    "@langchain/openai": ">=0.2.0 <0.4.0"
+    binary-extensions: ^2.2.0
+    expr-eval: ^2.0.2
+    flat: ^5.0.2
+    js-yaml: ^4.1.0
+    langchain: ">=0.2.3 <0.3.0 || >=0.3.4 <0.4.0"
+    langsmith: ">=0.2.8 <0.4.0"
+    uuid: ^10.0.0
+    zod: ^3.22.3
+    zod-to-json-schema: ^3.22.5
+  peerDependencies:
+    "@arcjet/redact": ^v1.0.0-alpha.23
+    "@aws-crypto/sha256-js": ^5.0.0
+    "@aws-sdk/client-bedrock-agent-runtime": ^3.583.0
+    "@aws-sdk/client-bedrock-runtime": ^3.422.0
+    "@aws-sdk/client-dynamodb": ^3.310.0
+    "@aws-sdk/client-kendra": ^3.352.0
+    "@aws-sdk/client-lambda": ^3.310.0
+    "@aws-sdk/client-s3": ^3.310.0
+    "@aws-sdk/client-sagemaker-runtime": ^3.310.0
+    "@aws-sdk/client-sfn": ^3.310.0
+    "@aws-sdk/credential-provider-node": ^3.388.0
+    "@azure/search-documents": ^12.0.0
+    "@azure/storage-blob": ^12.15.0
+    "@browserbasehq/sdk": "*"
+    "@browserbasehq/stagehand": ^1.0.0
+    "@clickhouse/client": ^0.2.5
+    "@cloudflare/ai": "*"
+    "@datastax/astra-db-ts": ^1.0.0
+    "@elastic/elasticsearch": ^8.4.0
+    "@getmetal/metal-sdk": "*"
+    "@getzep/zep-cloud": ^1.0.6
+    "@getzep/zep-js": ^0.9.0
+    "@gomomento/sdk": ^1.51.1
+    "@gomomento/sdk-core": ^1.51.1
+    "@google-ai/generativelanguage": "*"
+    "@google-cloud/storage": ^6.10.1 || ^7.7.0
+    "@gradientai/nodejs-sdk": ^1.2.0
+    "@huggingface/inference": ^2.6.4
+    "@huggingface/transformers": ^3.2.3
+    "@ibm-cloud/watsonx-ai": "*"
+    "@lancedb/lancedb": ^0.12.0
+    "@langchain/core": ">=0.2.21 <0.4.0"
+    "@layerup/layerup-security": ^1.5.12
+    "@libsql/client": ^0.14.0
+    "@mendable/firecrawl-js": ^1.4.3
+    "@mlc-ai/web-llm": "*"
+    "@mozilla/readability": "*"
+    "@neondatabase/serverless": "*"
+    "@notionhq/client": ^2.2.10
+    "@opensearch-project/opensearch": "*"
+    "@pinecone-database/pinecone": "*"
+    "@planetscale/database": ^1.8.0
+    "@premai/prem-sdk": ^0.3.25
+    "@qdrant/js-client-rest": ^1.8.2
+    "@raycast/api": ^1.55.2
+    "@rockset/client": ^0.9.1
+    "@smithy/eventstream-codec": ^2.0.5
+    "@smithy/protocol-http": ^3.0.6
+    "@smithy/signature-v4": ^2.0.10
+    "@smithy/util-utf8": ^2.0.0
+    "@spider-cloud/spider-client": ^0.0.21
+    "@supabase/supabase-js": ^2.45.0
+    "@tensorflow-models/universal-sentence-encoder": "*"
+    "@tensorflow/tfjs-converter": "*"
+    "@tensorflow/tfjs-core": "*"
+    "@upstash/ratelimit": ^1.1.3 || ^2.0.3
+    "@upstash/redis": ^1.20.6
+    "@upstash/vector": ^1.1.1
+    "@vercel/kv": "*"
+    "@vercel/postgres": "*"
+    "@writerai/writer-sdk": ^0.40.2
+    "@xata.io/client": ^0.28.0
+    "@zilliz/milvus2-sdk-node": ">=2.3.5"
+    apify-client: ^2.7.1
+    assemblyai: ^4.6.0
+    better-sqlite3: ">=9.4.0 <12.0.0"
+    cassandra-driver: ^4.7.2
+    cborg: ^4.1.1
+    cheerio: ^1.0.0-rc.12
+    chromadb: "*"
+    closevector-common: 0.1.3
+    closevector-node: 0.1.6
+    closevector-web: 0.1.6
+    cohere-ai: "*"
+    convex: ^1.3.1
+    crypto-js: ^4.2.0
+    d3-dsv: ^2.0.0
+    discord.js: ^14.14.1
+    dria: ^0.0.3
+    duck-duck-scrape: ^2.2.5
+    epub2: ^3.0.1
+    faiss-node: ^0.5.1
+    fast-xml-parser: "*"
+    firebase-admin: ^11.9.0 || ^12.0.0
+    google-auth-library: "*"
+    googleapis: "*"
+    hnswlib-node: ^3.0.0
+    html-to-text: ^9.0.5
+    ibm-cloud-sdk-core: "*"
+    ignore: ^5.2.0
+    interface-datastore: ^8.2.11
+    ioredis: ^5.3.2
+    it-all: ^3.0.4
+    jsdom: "*"
+    jsonwebtoken: ^9.0.2
+    llmonitor: ^0.5.9
+    lodash: ^4.17.21
+    lunary: ^0.7.10
+    mammoth: ^1.6.0
+    mongodb: ">=5.2.0"
+    mysql2: ^3.9.8
+    neo4j-driver: "*"
+    notion-to-md: ^3.1.0
+    officeparser: ^4.0.4
+    openai: "*"
+    pdf-parse: 1.1.1
+    pg: ^8.11.0
+    pg-copy-streams: ^6.0.5
+    pickleparser: ^0.2.1
+    playwright: ^1.32.1
+    portkey-ai: ^0.1.11
+    puppeteer: "*"
+    pyodide: ">=0.24.1 <0.27.0"
+    redis: "*"
+    replicate: ^0.29.4
+    sonix-speech-recognition: ^2.1.1
+    srt-parser-2: ^1.2.3
+    typeorm: ^0.3.20
+    typesense: ^1.5.3
+    usearch: ^1.1.1
+    voy-search: 0.6.2
+    weaviate-ts-client: "*"
+    web-auth-library: ^1.0.3
+    word-extractor: "*"
+    ws: ^8.14.2
+    youtubei.js: "*"
+  peerDependenciesMeta:
+    "@arcjet/redact":
+      optional: true
+    "@aws-crypto/sha256-js":
+      optional: true
+    "@aws-sdk/client-bedrock-agent-runtime":
+      optional: true
+    "@aws-sdk/client-bedrock-runtime":
+      optional: true
+    "@aws-sdk/client-dynamodb":
+      optional: true
+    "@aws-sdk/client-kendra":
+      optional: true
+    "@aws-sdk/client-lambda":
+      optional: true
+    "@aws-sdk/client-s3":
+      optional: true
+    "@aws-sdk/client-sagemaker-runtime":
+      optional: true
+    "@aws-sdk/client-sfn":
+      optional: true
+    "@aws-sdk/credential-provider-node":
+      optional: true
+    "@azure/search-documents":
+      optional: true
+    "@azure/storage-blob":
+      optional: true
+    "@browserbasehq/sdk":
+      optional: true
+    "@clickhouse/client":
+      optional: true
+    "@cloudflare/ai":
+      optional: true
+    "@datastax/astra-db-ts":
+      optional: true
+    "@elastic/elasticsearch":
+      optional: true
+    "@getmetal/metal-sdk":
+      optional: true
+    "@getzep/zep-cloud":
+      optional: true
+    "@getzep/zep-js":
+      optional: true
+    "@gomomento/sdk":
+      optional: true
+    "@gomomento/sdk-core":
+      optional: true
+    "@google-ai/generativelanguage":
+      optional: true
+    "@google-cloud/storage":
+      optional: true
+    "@gradientai/nodejs-sdk":
+      optional: true
+    "@huggingface/inference":
+      optional: true
+    "@huggingface/transformers":
+      optional: true
+    "@lancedb/lancedb":
+      optional: true
+    "@layerup/layerup-security":
+      optional: true
+    "@libsql/client":
+      optional: true
+    "@mendable/firecrawl-js":
+      optional: true
+    "@mlc-ai/web-llm":
+      optional: true
+    "@mozilla/readability":
+      optional: true
+    "@neondatabase/serverless":
+      optional: true
+    "@notionhq/client":
+      optional: true
+    "@opensearch-project/opensearch":
+      optional: true
+    "@pinecone-database/pinecone":
+      optional: true
+    "@planetscale/database":
+      optional: true
+    "@premai/prem-sdk":
+      optional: true
+    "@qdrant/js-client-rest":
+      optional: true
+    "@raycast/api":
+      optional: true
+    "@rockset/client":
+      optional: true
+    "@smithy/eventstream-codec":
+      optional: true
+    "@smithy/protocol-http":
+      optional: true
+    "@smithy/signature-v4":
+      optional: true
+    "@smithy/util-utf8":
+      optional: true
+    "@spider-cloud/spider-client":
+      optional: true
+    "@supabase/supabase-js":
+      optional: true
+    "@tensorflow-models/universal-sentence-encoder":
+      optional: true
+    "@tensorflow/tfjs-converter":
+      optional: true
+    "@tensorflow/tfjs-core":
+      optional: true
+    "@upstash/ratelimit":
+      optional: true
+    "@upstash/redis":
+      optional: true
+    "@upstash/vector":
+      optional: true
+    "@vercel/kv":
+      optional: true
+    "@vercel/postgres":
+      optional: true
+    "@writerai/writer-sdk":
+      optional: true
+    "@xata.io/client":
+      optional: true
+    "@zilliz/milvus2-sdk-node":
+      optional: true
+    apify-client:
+      optional: true
+    assemblyai:
+      optional: true
+    better-sqlite3:
+      optional: true
+    cassandra-driver:
+      optional: true
+    cborg:
+      optional: true
+    cheerio:
+      optional: true
+    chromadb:
+      optional: true
+    closevector-common:
+      optional: true
+    closevector-node:
+      optional: true
+    closevector-web:
+      optional: true
+    cohere-ai:
+      optional: true
+    convex:
+      optional: true
+    crypto-js:
+      optional: true
+    d3-dsv:
+      optional: true
+    discord.js:
+      optional: true
+    dria:
+      optional: true
+    duck-duck-scrape:
+      optional: true
+    epub2:
+      optional: true
+    faiss-node:
+      optional: true
+    fast-xml-parser:
+      optional: true
+    firebase-admin:
+      optional: true
+    google-auth-library:
+      optional: true
+    googleapis:
+      optional: true
+    hnswlib-node:
+      optional: true
+    html-to-text:
+      optional: true
+    ignore:
+      optional: true
+    interface-datastore:
+      optional: true
+    ioredis:
+      optional: true
+    it-all:
+      optional: true
+    jsdom:
+      optional: true
+    jsonwebtoken:
+      optional: true
+    llmonitor:
+      optional: true
+    lodash:
+      optional: true
+    lunary:
+      optional: true
+    mammoth:
+      optional: true
+    mongodb:
+      optional: true
+    mysql2:
+      optional: true
+    neo4j-driver:
+      optional: true
+    notion-to-md:
+      optional: true
+    officeparser:
+      optional: true
+    pdf-parse:
+      optional: true
+    pg:
+      optional: true
+    pg-copy-streams:
+      optional: true
+    pickleparser:
+      optional: true
+    playwright:
+      optional: true
+    portkey-ai:
+      optional: true
+    puppeteer:
+      optional: true
+    pyodide:
+      optional: true
+    redis:
+      optional: true
+    replicate:
+      optional: true
+    sonix-speech-recognition:
+      optional: true
+    srt-parser-2:
+      optional: true
+    typeorm:
+      optional: true
+    typesense:
+      optional: true
+    usearch:
+      optional: true
+    voy-search:
+      optional: true
+    weaviate-ts-client:
+      optional: true
+    web-auth-library:
+      optional: true
+    word-extractor:
+      optional: true
+    ws:
+      optional: true
+    youtubei.js:
+      optional: true
+  checksum: 220931ab4e749d7c07c6f676b09bd5e908a58d74803e4665f7d3a47be5fa40e0c2976535e2d750878f0f816d688784aa8303982f1af47e38595a4b4b884b1b49
+  languageName: node
+  linkType: hard
+
 "@langchain/core@npm:^0.3.13":
   version: 0.3.13
   resolution: "@langchain/core@npm:0.3.13"
@@ -2033,6 +2422,31 @@ __metadata:
   peerDependencies:
     "@langchain/core": ">=0.2.21 <0.4.0"
   checksum: f377fb4130adf435071da2fef36de3bf6850b4e7a41ec88b2096933364c103c38daf8a8d4becbe0a9c3194b2110a0094c2c017d04164af7861e973e3d088d466
+  languageName: node
+  linkType: hard
+
+"@langchain/openai@npm:>=0.1.0 <0.4.0, @langchain/openai@npm:>=0.2.0 <0.4.0":
+  version: 0.3.17
+  resolution: "@langchain/openai@npm:0.3.17"
+  dependencies:
+    js-tiktoken: ^1.0.12
+    openai: ^4.77.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.22.3
+  peerDependencies:
+    "@langchain/core": ">=0.3.29 <0.4.0"
+  checksum: af88894dcfa8381c0b0df924e085796995f5d5ba2a2657ea72b4181b35c5d92b0040c5cf305378c1f48a8f1f04d4a3b0b29ba1d84f80cedf5dab8bc46d7d5c6c
+  languageName: node
+  linkType: hard
+
+"@langchain/textsplitters@npm:>=0.0.0 <0.2.0":
+  version: 0.1.0
+  resolution: "@langchain/textsplitters@npm:0.1.0"
+  dependencies:
+    js-tiktoken: ^1.0.12
+  peerDependencies:
+    "@langchain/core": ">=0.2.21 <0.4.0"
+  checksum: f179113423b003968127abc0b41c23e9ba21bed9336745841bf54b95e283fc3cbfcd67e40d1b58922b89b35953caeb38d8d5d7a3a49c1c5b202f1542bf76dc3a
   languageName: node
   linkType: hard
 
@@ -3570,6 +3984,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"binary-extensions@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "binary-extensions@npm:2.3.0"
+  checksum: bcad01494e8a9283abf18c1b967af65ee79b0c6a9e6fcfafebfe91dbe6e0fc7272bafb73389e198b310516ae04f7ad17d79aacf6cb4c0d5d5202a7e2e52c7d98
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -3676,7 +4097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -3821,6 +4242,15 @@ __metadata:
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
   checksum: 902a9f5d8967a3e2faf138d5cb784b9979bad2e6db5357c5b21c568df4ebe62bcb15108af1b2253744844eb964fc023fbd9afbbbb6ddd0bcc204c6fb5b7bf3af
+  languageName: node
+  linkType: hard
+
+"console-table-printer@npm:^2.12.1":
+  version: 2.12.1
+  resolution: "console-table-printer@npm:2.12.1"
+  dependencies:
+    simple-wcswidth: ^1.0.1
+  checksum: 4d58fd4f18d3a69f421c9b0ffd44e5b0542677423491199e92c3e5ca0c023a06304a94bcc60f0d2b480a06cdf0720d2f228807f2af127abc8c905e73fcf64363
   languageName: node
   linkType: hard
 
@@ -4537,6 +4967,13 @@ __metadata:
   version: 1.1.1
   resolution: "exenv-es6@npm:1.1.1"
   checksum: 7f2aa12025e6f06c48dc286f380cf3183bb19c6017b36d91695034a3e5124a7235c4f8ff24ca2eb88ae801322f0f99605cedfcfd996a5fcbba7669320e2a448e
+  languageName: node
+  linkType: hard
+
+"expr-eval@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "expr-eval@npm:2.0.2"
+  checksum: 01862f09b50b17b45a6268b1153280afede99e1b51752a323661f7f4010eaed34cd6c682bf439b7f8a92df6aa82f326f0ce0aa20964d175feee97377fe53921d
   languageName: node
   linkType: hard
 
@@ -5620,6 +6057,94 @@ __metadata:
   languageName: node
   linkType: hard
 
+"langchain@npm:>=0.2.3 <0.3.0 || >=0.3.4 <0.4.0":
+  version: 0.3.12
+  resolution: "langchain@npm:0.3.12"
+  dependencies:
+    "@langchain/openai": ">=0.1.0 <0.4.0"
+    "@langchain/textsplitters": ">=0.0.0 <0.2.0"
+    js-tiktoken: ^1.0.12
+    js-yaml: ^4.1.0
+    jsonpointer: ^5.0.1
+    langsmith: ">=0.2.8 <0.4.0"
+    openapi-types: ^12.1.3
+    p-retry: 4
+    uuid: ^10.0.0
+    yaml: ^2.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.22.3
+  peerDependencies:
+    "@langchain/anthropic": "*"
+    "@langchain/aws": "*"
+    "@langchain/cerebras": "*"
+    "@langchain/cohere": "*"
+    "@langchain/core": ">=0.2.21 <0.4.0"
+    "@langchain/google-genai": "*"
+    "@langchain/google-vertexai": "*"
+    "@langchain/google-vertexai-web": "*"
+    "@langchain/groq": "*"
+    "@langchain/mistralai": "*"
+    "@langchain/ollama": "*"
+    axios: "*"
+    cheerio: "*"
+    handlebars: ^4.7.8
+    peggy: ^3.0.2
+    typeorm: "*"
+  peerDependenciesMeta:
+    "@langchain/anthropic":
+      optional: true
+    "@langchain/aws":
+      optional: true
+    "@langchain/cerebras":
+      optional: true
+    "@langchain/cohere":
+      optional: true
+    "@langchain/google-genai":
+      optional: true
+    "@langchain/google-vertexai":
+      optional: true
+    "@langchain/google-vertexai-web":
+      optional: true
+    "@langchain/groq":
+      optional: true
+    "@langchain/mistralai":
+      optional: true
+    "@langchain/ollama":
+      optional: true
+    axios:
+      optional: true
+    cheerio:
+      optional: true
+    handlebars:
+      optional: true
+    peggy:
+      optional: true
+    typeorm:
+      optional: true
+  checksum: b688575c48be29d597c64fe6d78b97e228a0577e14a875bfde1a7d60e9346877f61dd1e647669a9e75a09daecd2f61578b9beba610e35697312df6c8fa9df584
+  languageName: node
+  linkType: hard
+
+"langsmith@npm:>=0.2.8 <0.4.0":
+  version: 0.3.2
+  resolution: "langsmith@npm:0.3.2"
+  dependencies:
+    "@types/uuid": ^10.0.0
+    chalk: ^4.1.2
+    console-table-printer: ^2.12.1
+    p-queue: ^6.6.2
+    p-retry: 4
+    semver: ^7.6.3
+    uuid: ^10.0.0
+  peerDependencies:
+    openai: "*"
+  peerDependenciesMeta:
+    openai:
+      optional: true
+  checksum: b7fa447957b183cdd45a8729855e8bd7ef09b2c653491c2a0d244095c18d72df543cdaf64d3dc00bb6b360b50153853e131f2c91a5f6e838e58f180676ca8748
+  languageName: node
+  linkType: hard
+
 "langsmith@npm:^0.1.65":
   version: 0.1.66
   resolution: "langsmith@npm:0.1.66"
@@ -6155,6 +6680,38 @@ __metadata:
   dependencies:
     wrappy: 1
   checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
+  languageName: node
+  linkType: hard
+
+"openai@npm:^4.77.0":
+  version: 4.80.0
+  resolution: "openai@npm:4.80.0"
+  dependencies:
+    "@types/node": ^18.11.18
+    "@types/node-fetch": ^2.6.4
+    abort-controller: ^3.0.0
+    agentkeepalive: ^4.2.1
+    form-data-encoder: 1.7.2
+    formdata-node: ^4.3.2
+    node-fetch: ^2.6.7
+  peerDependencies:
+    ws: ^8.18.0
+    zod: ^3.23.8
+  peerDependenciesMeta:
+    ws:
+      optional: true
+    zod:
+      optional: true
+  bin:
+    openai: bin/cli
+  checksum: d20d5f34de510cad968e131d05290a1a0cda7d790944f701243f75db8223db8bdbdc373b2d90f69c1c14eceaf2fed65a500ef92726ec6d53a0f7306e83fbcc96
+  languageName: node
+  linkType: hard
+
+"openapi-types@npm:^12.1.3":
+  version: 12.1.3
+  resolution: "openapi-types@npm:12.1.3"
+  checksum: 7fa5547f87a58d2aa0eba6e91d396f42d7d31bc3ae140e61b5d60b47d2fd068b48776f42407d5a8da7280cf31195aa128c2fc285e8bb871d1105edee5647a0bb
   languageName: node
   linkType: hard
 
@@ -7053,6 +7610,13 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 64c757b498cb8629ffa5f75485340594d2f8189e9b08700e69199069c8e3070fb3e255f7ab873c05dc0b3cec412aea7402e10a5990cb6a050bd33ba062a6c549
+  languageName: node
+  linkType: hard
+
+"simple-wcswidth@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "simple-wcswidth@npm:1.0.1"
+  checksum: dc5bf4cb131d9c386825d1355add2b1ecc408b37dc2c2334edd7a1a4c9f527e6b594dedcdbf6d949bce2740c3a332e39af1183072a2d068e40d9e9146067a37f
   languageName: node
   linkType: hard
 
@@ -8240,6 +8804,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:^2.2.1":
+  version: 2.7.0
+  resolution: "yaml@npm:2.7.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 6e8b2f9b9d1b18b10274d58eb3a47ec223d9a93245a890dcb34d62865f7e744747190a9b9177d5f0ef4ea2e44ad2c0214993deb42e0800766203ac46f00a12dd
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^20.2.9":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
@@ -8269,6 +8842,22 @@ __metadata:
   peerDependencies:
     zod: ^3.23.3
   checksum: 0d51cf64b54fd39e86434cd5d2239c2981808e6461d022e4c68a1dec67fff28ef2b7bb5733dfd40eb50d6ce6d252288f3989d67134fa81401c36469bb26f13ec
+  languageName: node
+  linkType: hard
+
+"zod-to-json-schema@npm:^3.22.5":
+  version: 3.24.1
+  resolution: "zod-to-json-schema@npm:3.24.1"
+  peerDependencies:
+    zod: ^3.24.1
+  checksum: 7195563f611bc21ea7f44129b8e32780125a9bd98b2e6b8709ac98bd2645729fecd87b8aeeaa8789617ee3f38e6585bab23dd613e2a35c31c6c157908f7a1681
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.3":
+  version: 3.24.1
+  resolution: "zod@npm:3.24.1"
+  checksum: dcd5334725b29555593c186fd6505878bb7ccb4f5954f728d2de24bf71f9397492d83bdb69d5b8a376eb500a02273ae0691b57deb1eb8718df3f64c77cc5534a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Towards https://github.com/jupyterlite/ai/issues/24

Experimenting with built-in (on device) AI, such as Chrome AI: https://developer.chrome.com/docs/ai/built-in

`langchain.js` supports it as a text completion model, still experimental for now: https://js.langchain.com/docs/integrations/llms/chrome_ai/

This requires:

- using Google Chrome
- enabling some flags
- downloading the model (likely Gemini Nano), which should happen automatically on first use

One of the main advantages (omitting the browser limitation and required flag) is the zero setup needed (no API key).

https://github.com/user-attachments/assets/2043b789-fd00-475e-98db-ebbf3fd76ee0


