### PR TITLE
Add initial system prompt in ChatHandler and completion

### DIFF
--- a/src/chat-handler.ts
+++ b/src/chat-handler.ts
@@ -30,11 +30,11 @@ export class ChatHandler extends ChatModel {
   constructor(options: ChatHandler.IOptions) {
     super(options);
     this._aiProvider = options.aiProvider;
-    this._prompt = chatSystemPrompt(this._aiProvider.name);
+    this._prompt = chatSystemPrompt({ provider_name: this._aiProvider.name });
 
     this._aiProvider.modelChange.connect(() => {
       this._errorMessage = this._aiProvider.chatError;
-      this._prompt = chatSystemPrompt(this._aiProvider.name);
+      this._prompt = chatSystemPrompt({ provider_name: this._aiProvider.name });
     });
   }
 

--- a/src/llm-models/anthropic-completer.ts
+++ b/src/llm-models/anthropic-completer.ts
@@ -39,9 +39,7 @@ export class AnthropicCompleter implements IBaseCompleter {
     const trimmedPrompt = prompt.trim();
 
     const messages = [
-      new SystemMessage(
-        this._prompt
-      ),
+      new SystemMessage(this._prompt),
       new AIMessage(trimmedPrompt)
     ];
 

--- a/src/llm-models/anthropic-completer.ts
+++ b/src/llm-models/anthropic-completer.ts
@@ -7,6 +7,7 @@ import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { AIMessage, SystemMessage } from '@langchain/core/messages';
 
 import { BaseCompleter, IBaseCompleter } from './base-completer';
+import { COMPLETION_SYSTEM_PROMPT } from '../provider';
 
 export class AnthropicCompleter implements IBaseCompleter {
   constructor(options: BaseCompleter.IOptions) {
@@ -15,6 +16,16 @@ export class AnthropicCompleter implements IBaseCompleter {
 
   get provider(): BaseChatModel {
     return this._anthropicProvider;
+  }
+
+  /**
+   * Getter and setter for the initial prompt.
+   */
+  get prompt(): string {
+    return this._prompt;
+  }
+  set prompt(value: string) {
+    this._prompt = value;
   }
 
   async fetch(
@@ -29,7 +40,7 @@ export class AnthropicCompleter implements IBaseCompleter {
 
     const messages = [
       new SystemMessage(
-        'You are a code-completion AI completing the following code from a Jupyter Notebook cell.'
+        this._prompt
       ),
       new AIMessage(trimmedPrompt)
     ];
@@ -62,4 +73,5 @@ export class AnthropicCompleter implements IBaseCompleter {
   }
 
   private _anthropicProvider: ChatAnthropic;
+  private _prompt: string = COMPLETION_SYSTEM_PROMPT;
 }

--- a/src/llm-models/base-completer.ts
+++ b/src/llm-models/base-completer.ts
@@ -12,6 +12,11 @@ export interface IBaseCompleter {
   provider: BaseLanguageModel;
 
   /**
+   * The completion prompt.
+   */
+  prompt: string;
+
+  /**
    * The function to fetch a new completion.
    */
   requestCompletion?: () => void;

--- a/src/llm-models/codestral-completer.ts
+++ b/src/llm-models/codestral-completer.ts
@@ -8,6 +8,7 @@ import { Throttler } from '@lumino/polling';
 import { CompletionRequest } from '@mistralai/mistralai';
 
 import { BaseCompleter, IBaseCompleter } from './base-completer';
+import { COMPLETION_SYSTEM_PROMPT } from '../provider';
 
 /**
  * The Mistral API has a rate limit of 1 request per second
@@ -66,6 +67,16 @@ export class CodestralCompleter implements IBaseCompleter {
     return this._mistralProvider;
   }
 
+  /**
+   * Getter and setter for the initial prompt.
+   */
+  get prompt(): string {
+    return this._prompt;
+  }
+  set prompt(value: string) {
+    this._prompt = value;
+  }
+
   set requestCompletion(value: () => void) {
     this._requestCompletion = value;
   }
@@ -109,5 +120,6 @@ export class CodestralCompleter implements IBaseCompleter {
   private _requestCompletion?: () => void;
   private _throttler: Throttler;
   private _mistralProvider: MistralAI;
+  private _prompt: string = COMPLETION_SYSTEM_PROMPT;
   private _currentData: CompletionRequest | null = null;
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,9 +8,9 @@ import { CompletionProvider } from './completion-provider';
 import { getChatModel, IBaseCompleter } from './llm-models';
 import { IAIProvider } from './token';
 
-export const chatSystemPrompt = (provider_name: string) => `
+export const chatSystemPrompt = (options: AIProvider.IPromptOptions) => `
 You are Jupyternaut, a conversational assistant living in JupyterLab to help users.
-You are not a language model, but rather an application built on a foundation model from ${provider_name}.
+You are not a language model, but rather an application built on a foundation model from ${options.provider_name}.
 You are talkative and you provide lots of specific details from the foundation model's context.
 You may use Markdown to format your response.
 If your response includes code, they must be enclosed in Markdown fenced code blocks (with triple backticks before and after).
@@ -132,6 +132,16 @@ export namespace AIProvider {
      * The application commands registry.
      */
     requestCompletion: () => void;
+  }
+
+  /**
+   * The options for the Chat system prompt.
+   */
+  export interface IPromptOptions {
+    /**
+     * The provider name.
+     */
+    provider_name: string;
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,6 +8,30 @@ import { CompletionProvider } from './completion-provider';
 import { getChatModel, IBaseCompleter } from './llm-models';
 import { IAIProvider } from './token';
 
+export const chatSystemPrompt = (provider_name: string) => `
+You are Jupyternaut, a conversational assistant living in JupyterLab to help users.
+You are not a language model, but rather an application built on a foundation model from ${provider_name}.
+You are talkative and you provide lots of specific details from the foundation model's context.
+You may use Markdown to format your response.
+If your response includes code, they must be enclosed in Markdown fenced code blocks (with triple backticks before and after).
+If your response includes mathematical notation, they must be expressed in LaTeX markup and enclosed in LaTeX delimiters.
+All dollar quantities (of USD) must be formatted in LaTeX, with the \`$\` symbol escaped by a single backslash \`\\\`.
+- Example prompt: \`If I have \\\\$100 and spend \\\\$20, how much money do I have left?\`
+- **Correct** response: \`You have \\(\\$80\\) remaining.\`
+- **Incorrect** response: \`You have $80 remaining.\`
+If you do not know the answer to a question, answer truthfully by responding that you do not know.
+The following is a friendly conversation between you and a human.
+`;
+
+export const COMPLETION_SYSTEM_PROMPT = `
+You are an application built to provide helpful code completion suggestions.
+You should only produce code. Keep comments to minimum, use the
+programming language comment syntax. Produce clean code.
+The code is written in JupyterLab, a data analysis and code development
+environment which can execute code extended with additional syntax for
+interactive features, such as magics.
+`;
+
 export class AIProvider implements IAIProvider {
   constructor(options: AIProvider.IOptions) {
     this._completionProvider = new CompletionProvider({


### PR DESCRIPTION
Fixes https://github.com/jupyterlite/ai/issues/25

Use the same prompts as `jupyter-ai` (except for the model name, which is not part of the `BaseChatModel` and may not be provided by all chat model).

### NOTES
1. Currently the completion prompt is not used by the codestral completer, because the codestral completer uses a [text completion model](https://js.langchain.com/docs/integrations/llms/), which doesn't seem to allow such prompts.

2. For a follow up PR, we should:

    - use a chat model for codestral instead of LLM (as expressed in https://github.com/jupyterlite/ai/issues/9#issue-2613421821)
      > do we need to instantiate both a MistralAI and ChatMistralAI clients?
    - create a `BaseCompleter` class that may fit with most of the completers

### FOLLOW UP

We could add a setting to let user define their own prompt https://github.com/jupyterlite/ai/issues/25#issuecomment-2615100692