### PR TITLE
Upgrade the jupyterlite-core package in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,8 @@ jobs:
           python-version: '3.11'
       - name: Install the dependencies
         run: |
-          python -m pip install jupyterlite-core jupyterlite-pyodide-kernel
+          python -m pip install jupyterlite-core --pre
+          python -m pip install jupyterlite-pyodide-kernel
 
           # install a dev version of the extension
           python -m pip install .


### PR DESCRIPTION
Upgrade the version of `jupyterlite-core` to the pre-released one in the deployment (https://jupyterlite.github.io/ai/lab/index.html), to allow dynamic settings.

Otherwise, the page has to be reloaded to fill the required `API key` settings.

![Peek 2025-01-28 14-43](https://github.com/user-attachments/assets/0e8893aa-2ddb-42db-8648-a116bbe97695)

