### PR TITLE
Fix installation of pre-released jupyterlite in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,8 @@ jobs:
           python-version: '3.11'
       - name: Install the dependencies
         run: |
-          python -m pip install jupyterlite-core --pre
           python -m pip install jupyterlite-pyodide-kernel
+          python -m pip install jupyterlite-core --pre
 
           # install a dev version of the extension
           python -m pip install .


### PR DESCRIPTION
Follow up #30 

Installing `jupyterlite-pyodide-kernel` for deployment uninstall the `jupyterlite-core` in pre released version to install a stable one (see logs https://github.com/jupyterlite/ai/actions/runs/13032803966/job/36355795861#step:4:64)

This PR install first `jupyterlite-pyodide-kernel` and then `jupyterlite-core --pre`