### PR TITLE
Completer plugin

### DIFF
--- a/src/chat-handler.ts
+++ b/src/chat-handler.ts
@@ -40,7 +40,7 @@ export class ChatHandler extends ChatModel {
     this._aiProvider = options.aiProvider;
     this._prompt = chatSystemPrompt({ provider_name: this._aiProvider.name });
 
-    this._aiProvider.modelChange.connect(() => {
+    this._aiProvider.providerChanged.connect(() => {
       this._errorMessage = this._aiProvider.chatError;
       this._prompt = chatSystemPrompt({ provider_name: this._aiProvider.name });
     });

--- a/src/completion-provider.ts
+++ b/src/completion-provider.ts
@@ -17,7 +17,7 @@ export class CompletionProvider implements IInlineCompletionProvider {
     this._aiProvider = options.aiProvider;
     this._requestCompletion = options.requestCompletion;
 
-    this._aiProvider.modelChange.connect(() => {
+    this._aiProvider.providerChanged.connect(() => {
       if (this.completer) {
         this.completer.requestCompletion = this._requestCompletion;
       }

--- a/src/completion-provider.ts
+++ b/src/completion-provider.ts
@@ -3,10 +3,9 @@ import {
   IInlineCompletionContext,
   IInlineCompletionProvider
 } from '@jupyterlab/completer';
-import { BaseLanguageModel } from '@langchain/core/language_models/base';
-import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 
-import { getCompleter, IBaseCompleter, BaseCompleter } from './llm-models';
+import { IBaseCompleter } from './llm-models';
+import { IAIProvider } from './token';
 
 /**
  * The generic completion provider to register to the completion provider manager.
@@ -15,67 +14,44 @@ export class CompletionProvider implements IInlineCompletionProvider {
   readonly identifier = '@jupyterlite/ai';
 
   constructor(options: CompletionProvider.IOptions) {
-    const { name, settings } = options;
+    this._aiProvider = options.aiProvider;
     this._requestCompletion = options.requestCompletion;
-    this.setCompleter(name, settings);
-  }
 
-  /**
-   * Set the completer.
-   *
-   * @param name - the name of the completer.
-   * @param settings - The settings associated to the completer.
-   */
-  setCompleter(name: string, settings: ReadonlyPartialJSONObject) {
-    try {
-      this._completer = getCompleter(name, settings);
-      if (this._completer) {
-        this._completer.requestCompletion = this._requestCompletion;
+    this._aiProvider.modelChange.connect(() => {
+      if (this.completer) {
+        this.completer.requestCompletion = this._requestCompletion;
       }
-      this._name = this._completer === null ? 'None' : name;
-    } catch (e: any) {
-      this._completer = null;
-      this._name = 'None';
-      throw e;
-    }
+    });
   }
 
   /**
    * Get the current completer name.
    */
   get name(): string {
-    return this._name;
+    return this._aiProvider.name;
   }
 
   /**
    * Get the current completer.
    */
   get completer(): IBaseCompleter | null {
-    return this._completer;
-  }
-
-  /**
-   * Get the LLM completer.
-   */
-  get llmCompleter(): BaseLanguageModel | null {
-    return this._completer?.provider || null;
+    return this._aiProvider.completer;
   }
 
   async fetch(
     request: CompletionHandler.IRequest,
     context: IInlineCompletionContext
   ) {
-    return this._completer?.fetch(request, context);
+    return this.completer?.fetch(request, context);
   }
 
-  private _name: string = 'None';
+  private _aiProvider: IAIProvider;
   private _requestCompletion: () => void;
-  private _completer: IBaseCompleter | null = null;
 }
 
 export namespace CompletionProvider {
-  export interface IOptions extends BaseCompleter.IOptions {
-    name: string;
+  export interface IOptions {
+    aiProvider: IAIProvider;
     requestCompletion: () => void;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ const aiProviderPlugin: JupyterFrontEndPlugin<IAIProvider> = {
           }
 
           // Update the settings to the AI providers.
-          aiProvider.setModels(provider, settings.composite);
+          aiProvider.setProvider(provider, settings.composite);
         };
 
         settings.changed.connect(() => updateProvider());

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -78,13 +78,13 @@ export class AIProvider implements IAIProvider {
   }
 
   /**
-   * Set the models (chat model and completer).
-   * Creates the models if the name has changed, otherwise only updates their config.
+   * Set the provider (chat model and completer).
+   * Creates the providers if the name has changed, otherwise only updates their config.
    *
-   * @param name - the name of the model to use.
+   * @param name - the name of the provider to use.
    * @param settings - the settings for the models.
    */
-  setModels(name: string, settings: ReadonlyPartialJSONObject) {
+  setProvider(name: string, settings: ReadonlyPartialJSONObject) {
     try {
       this._completer = getCompleter(name, settings);
       this._completerError = '';
@@ -99,17 +99,17 @@ export class AIProvider implements IAIProvider {
       this._llmChatModel = null;
     }
     this._name = name;
-    this._modelChange.emit();
+    this._providerChanged.emit();
   }
 
-  get modelChange(): ISignal<IAIProvider, void> {
-    return this._modelChange;
+  get providerChanged(): ISignal<IAIProvider, void> {
+    return this._providerChanged;
   }
 
   private _completer: IBaseCompleter | null = null;
   private _llmChatModel: BaseChatModel | null = null;
   private _name: string = 'None';
-  private _modelChange = new Signal<IAIProvider, void>(this);
+  private _providerChanged = new Signal<IAIProvider, void>(this);
   private _chatError: string = '';
   private _completerError: string = '';
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -8,7 +8,7 @@ export interface IAIProvider {
   name: string;
   completer: IBaseCompleter | null;
   chatModel: BaseChatModel | null;
-  modelChange: ISignal<IAIProvider, void>;
+  providerChanged: ISignal<IAIProvider, void>;
   chatError: string;
   completerError: string;
 }


### PR DESCRIPTION
This PR add a new plugin for the completion provider, for more consistency with the chat plugin.

Before, the completion provider was embedded in the `AIProvider`, whereas the chat was instantiated in a plugin, and was listening for changes in the AIProvider.

Now, the completion provider is also instantiating in a plugin, and is also listening for change in the AIProvider.
This add more flexibility to disable one of the chat or completer.

It also rename some attributes/function in the `AIProvider`, from model to provider to avoid confusion with the model name of each LLM provider.
