### PR TITLE
Use the secrets manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "@rjsf/core": "^4.2.0",
         "@rjsf/utils": "^5.18.4",
         "@rjsf/validator-ajv8": "^5.18.4",
+        "jupyter-secrets-manager": "^0.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "jupyter-secrets-manager"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/schema/provider-registry.json
+++ b/schema/provider-registry.json
@@ -5,6 +5,12 @@
   "jupyter.lab.setting-icon-label": "JupyterLite AI Chat",
   "type": "object",
   "properties": {
+    "UseSecretsManager": {
+      "type": "boolean",
+      "title": "Use secrets manager",
+      "description": "Whether to use or not the secrets manager. If not, secrets will be stored in the browser (local storage)",
+      "default": true
+    },
     "AIprovider": {
       "type": "object",
       "title": "AI provider",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IFormRendererRegistry } from '@jupyterlab/ui-components';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
+import { ISecretsManager } from 'jupyter-secrets-manager';
 
 import { ChatHandler } from './chat-handler';
 import { CompletionProvider } from './completion-provider';
@@ -137,19 +138,20 @@ const providerRegistryPlugin: JupyterFrontEndPlugin<IAIProviderRegistry> = {
   id: '@jupyterlite/ai:provider-registry',
   autoStart: true,
   requires: [IFormRendererRegistry, ISettingRegistry],
-  optional: [IRenderMimeRegistry],
+  optional: [IRenderMimeRegistry, ISecretsManager],
   provides: IAIProviderRegistry,
   activate: (
     app: JupyterFrontEnd,
     editorRegistry: IFormRendererRegistry,
     settingRegistry: ISettingRegistry,
-    rmRegistry?: IRenderMimeRegistry
+    rmRegistry?: IRenderMimeRegistry,
+    secretsManager?: ISecretsManager
   ): IAIProviderRegistry => {
     const providerRegistry = new AIProviderRegistry();
 
     editorRegistry.addRenderer(
       '@jupyterlite/ai:provider-registry.AIprovider',
-      aiSettingsRenderer({ providerRegistry, rmRegistry })
+      aiSettingsRenderer({ providerRegistry, rmRegistry, secretsManager })
     );
     settingRegistry
       .load(providerRegistryPlugin.id)

--- a/src/settings/panel.tsx
+++ b/src/settings/panel.tsx
@@ -102,21 +102,7 @@ export class AiSettings extends React.Component<
       .catch(console.error);
   }
 
-  async componentWillUpdate(): Promise<void> {
-    if (!this._secretsManager) {
-      return;
-    }
-    const inputs = this._formRef.current?.getElementsByTagName('input') || [];
-    for (let i = 0; i < inputs.length; i++) {
-      if (inputs[i].type.toLowerCase() === 'password') {
-        (await this._secretsManager.list(SECRETS_NAMESPACE)).forEach(id =>
-          this._secretsManager?.detach(SECRETS_NAMESPACE, id)
-        );
-      }
-    }
-  }
-
-  componentDidUpdate(): void {
+  async componentDidUpdate(): Promise<void> {
     if (!this._secretsManager) {
       return;
     }
@@ -125,6 +111,8 @@ export class AiSettings extends React.Component<
     if (ArrayExt.shallowEqual(inputs, this._formInputs)) {
       return;
     }
+
+    await this._secretsManager?.detachAll(SECRETS_NAMESPACE);
     this._formInputs = [...inputs];
     this._unsavedFields = [];
     for (let i = 0; i < inputs.length; i++) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,6 +970,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/application@npm:^4.0.0":
+  version: 4.3.5
+  resolution: "@jupyterlab/application@npm:4.3.5"
+  dependencies:
+    "@fortawesome/fontawesome-free": ^5.12.0
+    "@jupyterlab/apputils": ^4.4.5
+    "@jupyterlab/coreutils": ^6.3.5
+    "@jupyterlab/docregistry": ^4.3.5
+    "@jupyterlab/rendermime": ^4.3.5
+    "@jupyterlab/rendermime-interfaces": ^3.11.5
+    "@jupyterlab/services": ^7.3.5
+    "@jupyterlab/statedb": ^4.3.5
+    "@jupyterlab/translation": ^4.3.5
+    "@jupyterlab/ui-components": ^4.3.5
+    "@lumino/algorithm": ^2.0.2
+    "@lumino/application": ^2.4.1
+    "@lumino/commands": ^2.3.1
+    "@lumino/coreutils": ^2.2.0
+    "@lumino/disposable": ^2.1.3
+    "@lumino/messaging": ^2.0.2
+    "@lumino/polling": ^2.1.3
+    "@lumino/properties": ^2.0.2
+    "@lumino/signaling": ^2.1.3
+    "@lumino/widgets": ^2.5.0
+  checksum: 2111efe2caafed74a78c2ddd6220baa6ccc459c27bde3cc80a0a53a403ad08ae2f0b3ea2e56e24b13440bc6fb3d254fc5519536127f47bd50a496bc44458aeb1
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/application@npm:^4.2.0, @jupyterlab/application@npm:^4.4.0-alpha.0":
   version: 4.4.0-alpha.2
   resolution: "@jupyterlab/application@npm:4.4.0-alpha.2"
@@ -1843,7 +1871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/statedb@npm:^4.3.5":
+"@jupyterlab/statedb@npm:^4.0.0, @jupyterlab/statedb@npm:^4.3.5":
   version: 4.3.5
   resolution: "@jupyterlab/statedb@npm:4.3.5"
   dependencies:
@@ -2071,6 +2099,7 @@ __metadata:
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^5.0.0
+    jupyter-secrets-manager: ^0.1.1
     npm-run-all: ^4.1.5
     prettier: ^3.0.0
     react: ^18.2.0
@@ -2739,7 +2768,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/algorithm@npm:^2.0.1, @lumino/algorithm@npm:^2.0.2":
+"@lumino/algorithm@npm:^2.0.0, @lumino/algorithm@npm:^2.0.1, @lumino/algorithm@npm:^2.0.2":
   version: 2.0.2
   resolution: "@lumino/algorithm@npm:2.0.2"
   checksum: 34b25684b845f1bdbf78ca45ebd99a97b67b2992440c9643aafe5fc5a99fae1ddafa9e5890b246b233dc3a12d9f66aa84afe4a2aac44cf31071348ed217740db
@@ -6185,6 +6214,18 @@ __metadata:
   version: 5.0.1
   resolution: "jsonpointer@npm:5.0.1"
   checksum: 0b40f712900ad0c846681ea2db23b6684b9d5eedf55807b4708c656f5894b63507d0e28ae10aa1bddbea551241035afe62b6df0800fc94c2e2806a7f3adecd7c
+  languageName: node
+  linkType: hard
+
+"jupyter-secrets-manager@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "jupyter-secrets-manager@npm:0.1.1"
+  dependencies:
+    "@jupyterlab/application": ^4.0.0
+    "@jupyterlab/statedb": ^4.0.0
+    "@lumino/algorithm": ^2.0.0
+    "@lumino/coreutils": ^2.1.2
+  checksum: 608b1ad45dd037362caf0db1555d833203985d4069091da91f4407c80a21d6acadbf86a322d8e0b6c476089d8edd8a634f0978a57565fe76842920822e9ce2c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR uses the secrets manager to handle passwords in settings.

~~The tests are not intended to work, since the secrets manager package has not been published yet.
To test it, one should install locally [jupyter-secrets-manager](https://github.com/jupyterlab-contrib/jupyter-secrets-manager) and use [yalc](https://github.com/wclr/yalc) to link the Javascript package.~~

