### PR TITLE
Avoid building settings schemas when building javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "url": "https://github.com/jupyterlite/ai.git"
     },
     "scripts": {
-        "build": "jlpm settings:build && jlpm build:lib && jlpm build:labextension:dev",
+        "build": "jlpm build:lib && jlpm build:labextension:dev",
         "build:dev": "jlpm build:lib && jlpm build:labextension:dev",
         "build:prod": "jlpm settings:build && jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
         "build:labextension": "jupyter labextension build .",


### PR DESCRIPTION
This remove a leftover script that build the settings schemas when building the jaascript.
 
Follow up #58 which add the settings schemas in the repository.