### PR TITLE
Do not store passwords to server settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "@rjsf/utils": "^5.18.4",
         "@rjsf/validator-ajv8": "^5.18.4",
         "json5": "^2.2.3",
-        "jupyter-secrets-manager": "^0.1.1",
+        "jupyter-secrets-manager": "^0.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
         "extension": true,
         "outputDir": "jupyterlite_ai/labextension",
         "schemaDir": "schema",
-        "disabledExtensions": ["@jupyterlab/apputils-extension:settings-connector"]
+        "disabledExtensions": [
+            "@jupyterlab/apputils-extension:settings-connector"
+        ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "@jupyterlab/completer": "^4.4.0-alpha.0",
         "@jupyterlab/notebook": "^4.4.0-alpha.0",
         "@jupyterlab/rendermime": "^4.4.0-alpha.0",
-        "@jupyterlab/settingregistry": "^4.4.0-alpha.0",
+        "@jupyterlab/settingregistry": "^4.4.0-beta.1",
         "@jupyterlab/ui-components": "^4.4.0-alpha.0",
         "@langchain/anthropic": "^0.3.9",
         "@langchain/community": "^0.3.31",
@@ -77,6 +77,7 @@
         "@rjsf/core": "^4.2.0",
         "@rjsf/utils": "^5.18.4",
         "@rjsf/validator-ajv8": "^5.18.4",
+        "json5": "^2.2.3",
         "jupyter-secrets-manager": "^0.1.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -118,6 +119,7 @@
     "jupyterlab": {
         "extension": true,
         "outputDir": "jupyterlite_ai/labextension",
-        "schemaDir": "schema"
+        "schemaDir": "schema",
+        "disabledExtensions": ["@jupyterlab/apputils-extension:settings-connector"]
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,9 @@ dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
 jupyter = [
-    "jupyterlab>=4.4.0a0",
+    "jupyterlab>=4.4.0b1",
     "jupyterlite>=0.6.0a0",
-    "notebook>=7.4.0a0"
+    "notebook>=7.4.0b1"
 ]
 
 [tool.hatch.version]

--- a/src/completion-provider.ts
+++ b/src/completion-provider.ts
@@ -51,7 +51,14 @@ export class CompletionProvider implements IInlineCompletionProvider {
 
 export namespace CompletionProvider {
   export interface IOptions {
+    /**
+     * The registry where the completion provider belongs.
+     */
     providerRegistry: IAIProviderRegistry;
+    /**
+     * The request completion commands, can be useful if a provider needs to request
+     * the completion by itself.
+     */
     requestCompletion: () => void;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,10 +171,10 @@ const providerRegistryPlugin: JupyterFrontEndPlugin<IAIProviderRegistry> = {
           const providerSettings = (settings.get('AIprovider').composite ?? {
             provider: 'None'
           }) as ReadonlyPartialJSONObject;
-          providerRegistry.setProvider(
-            providerSettings.provider as string,
-            providerSettings
-          );
+          providerRegistry.setProvider({
+            name: providerSettings.provider as string,
+            settings: providerSettings
+          });
         };
 
         settings.changed.connect(() => updateProvider());

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,8 @@ import { ChatHandler } from './chat-handler';
 import { CompletionProvider } from './completion-provider';
 import { defaultProviderPlugins } from './default-providers';
 import { AIProviderRegistry } from './provider';
-import { aiSettingsRenderer } from './settings/panel';
+import { aiSettingsRenderer, SettingConnector } from './settings';
 import { IAIProviderRegistry } from './tokens';
-import { SettingConnector } from './settings/settings-connector';
 
 const chatCommandRegistryPlugin: JupyterFrontEndPlugin<IChatCommandRegistry> = {
   id: '@jupyterlite/ai:autocompletion-registry',
@@ -152,7 +151,7 @@ const providerRegistryPlugin: JupyterFrontEndPlugin<IAIProviderRegistry> = {
     secretsManager?: ISecretsManager,
     settingConnector?: ISettingConnector
   ): IAIProviderRegistry => {
-    const providerRegistry = new AIProviderRegistry();
+    const providerRegistry = new AIProviderRegistry({ secretsManager });
 
     editorRegistry.addRenderer(
       '@jupyterlite/ai:provider-registry.AIprovider',

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,0 +1,3 @@
+export * from './panel';
+export * from './settings-connector';
+export * from './utils';

--- a/src/settings/panel.tsx
+++ b/src/settings/panel.tsx
@@ -13,11 +13,10 @@ import { JSONSchema7 } from 'json-schema';
 import { ISecretsManager } from 'jupyter-secrets-manager';
 import React from 'react';
 
+import { getSecretId, SECRETS_NAMESPACE, SettingConnector } from '.';
 import baseSettings from './base.json';
-import { SettingConnector } from './settings-connector';
 import { IAIProviderRegistry, IDict } from '../tokens';
 
-const SECRETS_NAMESPACE = '@jupyterlite/ai';
 const MD_MIME_TYPE = 'text/markdown';
 const STORAGE_NAME = '@jupyterlite/ai:settings';
 const INSTRUCTION_CLASS = 'jp-AISettingsInstructions';
@@ -136,7 +135,7 @@ export class AiSettings extends React.Component<
       if (inputs[i].type.toLowerCase() === 'password') {
         const label = inputs[i].getAttribute('label');
         if (label) {
-          const id = `${this._provider}-${label}`;
+          const id = getSecretId(this._provider, label);
           this._secretsManager.attach(
             SECRETS_NAMESPACE,
             id,

--- a/src/settings/settings-connector.ts
+++ b/src/settings/settings-connector.ts
@@ -1,0 +1,81 @@
+import { PageConfig } from '@jupyterlab/coreutils';
+import {
+  ISettingConnector,
+  ISettingRegistry
+} from '@jupyterlab/settingregistry';
+import { DataConnector, IDataConnector } from '@jupyterlab/statedb';
+import { Throttler } from '@lumino/polling';
+import * as json5 from 'json5';
+
+/**
+ * A data connector for fetching settings.
+ *
+ * #### Notes
+ * This connector adds a query parameter to the base services setting manager.
+ */
+export class SettingConnector
+  extends DataConnector<ISettingRegistry.IPlugin, string>
+  implements ISettingConnector
+{
+  constructor(connector: IDataConnector<ISettingRegistry.IPlugin, string>) {
+    super();
+    this._connector = connector;
+  }
+
+  set doNotSave(fields: string[]) {
+    this._doNotSave = [...fields];
+  }
+
+  /**
+   * Fetch settings for a plugin.
+   * @param id - The plugin ID
+   *
+   * #### Notes
+   * The REST API requests are throttled at one request per plugin per 100ms.
+   */
+  fetch(id: string): Promise<ISettingRegistry.IPlugin | undefined> {
+    const throttlers = this._throttlers;
+    if (!(id in throttlers)) {
+      throttlers[id] = new Throttler(() => this._connector.fetch(id), 100);
+    }
+    return throttlers[id].invoke();
+  }
+
+  async list(query: 'ids'): Promise<{ ids: string[] }>;
+  async list(
+    query: 'active' | 'all'
+  ): Promise<{ ids: string[]; values: ISettingRegistry.IPlugin[] }>;
+  async list(
+    query: 'active' | 'all' | 'ids' = 'all'
+  ): Promise<{ ids: string[]; values?: ISettingRegistry.IPlugin[] }> {
+    const { isDisabled } = PageConfig.Extension;
+    const { ids, values } = await this._connector.list(
+      query === 'ids' ? 'ids' : undefined
+    );
+
+    if (query === 'all') {
+      return { ids, values };
+    }
+
+    if (query === 'ids') {
+      return { ids };
+    }
+
+    return {
+      ids: ids.filter(id => !isDisabled(id)),
+      values: values.filter(({ id }) => !isDisabled(id))
+    };
+  }
+
+  async save(id: string, raw: string): Promise<void> {
+    const settings = json5.parse(raw);
+    this._doNotSave.forEach(field => {
+      delete settings['AIprovider']?.[field];
+    });
+    await this._connector.save(id, raw);
+  }
+
+  private _connector: IDataConnector<ISettingRegistry.IPlugin, string>;
+  private _doNotSave: string[] = [];
+  private _throttlers: { [key: string]: Throttler } = Object.create(null);
+}

--- a/src/settings/settings-connector.ts
+++ b/src/settings/settings-connector.ts
@@ -7,6 +7,8 @@ import { DataConnector, IDataConnector } from '@jupyterlab/statedb';
 import { Throttler } from '@lumino/polling';
 import * as json5 from 'json5';
 
+import { SECRETS_REPLACEMENT } from '.';
+
 /**
  * A data connector for fetching settings.
  *
@@ -70,9 +72,15 @@ export class SettingConnector
   async save(id: string, raw: string): Promise<void> {
     const settings = json5.parse(raw);
     this._doNotSave.forEach(field => {
-      delete settings['AIprovider']?.[field];
+      if (
+        settings['AIprovider'] !== undefined &&
+        settings['AIprovider'][field] !== undefined &&
+        settings['AIprovider'][field] !== ''
+      ) {
+        settings['AIprovider'][field] = SECRETS_REPLACEMENT;
+      }
     });
-    await this._connector.save(id, raw);
+    await this._connector.save(id, json5.stringify(settings, null, 2));
   }
 
   private _connector: IDataConnector<ISettingRegistry.IPlugin, string>;

--- a/src/settings/utils.ts
+++ b/src/settings/utils.ts
@@ -1,0 +1,6 @@
+export const SECRETS_NAMESPACE = '@jupyterlite/ai';
+export const SECRETS_REPLACEMENT = '***';
+
+export function getSecretId(provider: string, label: string) {
+  return `${provider}-${label}`;
+}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -85,10 +85,9 @@ export interface IAIProviderRegistry {
    * Set the providers (chat model and completer).
    * Creates the providers if the name has changed, otherwise only updates their config.
    *
-   * @param name - the name of the provider to use.
-   * @param settings - the settings for the models.
+   * @param options - an object with the name and the settings of the provider to use.
    */
-  setProvider(name: string, settings: ReadonlyPartialJSONObject): void;
+  setProvider(options: ISetProviderOptions): void;
   /**
    * A signal emitting when the provider or its settings has changed.
    */
@@ -101,6 +100,20 @@ export interface IAIProviderRegistry {
    * get the current completer error.
    */
   readonly completerError: string;
+}
+
+/**
+ * The set provider options.
+ */
+export interface ISetProviderOptions {
+  /**
+   * The name of the provider.
+   */
+  name: string;
+  /**
+   * The settings of the provider.
+   */
+  settings: ReadonlyPartialJSONObject;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2140,6 +2140,7 @@ __metadata:
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^5.0.0
+    json5: ^2.2.3
     jupyter-secrets-manager: ^0.1.1
     npm-run-all: ^4.1.5
     prettier: ^3.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,7 +2141,7 @@ __metadata:
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^5.0.0
     json5: ^2.2.3
-    jupyter-secrets-manager: ^0.1.1
+    jupyter-secrets-manager: ^0.2.0
     npm-run-all: ^4.1.5
     prettier: ^3.0.0
     react: ^18.2.0
@@ -6259,15 +6259,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jupyter-secrets-manager@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "jupyter-secrets-manager@npm:0.1.1"
+"jupyter-secrets-manager@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "jupyter-secrets-manager@npm:0.2.0"
   dependencies:
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/statedb": ^4.0.0
     "@lumino/algorithm": ^2.0.0
     "@lumino/coreutils": ^2.1.2
-  checksum: 608b1ad45dd037362caf0db1555d833203985d4069091da91f4407c80a21d6acadbf86a322d8e0b6c476089d8edd8a634f0978a57565fe76842920822e9ce2c0
+  checksum: 7745809a2b1922247b100ed36fabf8ffaa96c73b4343233ce70bfffec1ff131ac365a190e2661516642f57f9d84c6f0a834643bbbf7ebc98579ae2961bcc645f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,6 +1649,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jupyterlab/nbformat@npm:^4.4.0-beta.1":
+  version: 4.4.0-beta.1
+  resolution: "@jupyterlab/nbformat@npm:4.4.0-beta.1"
+  dependencies:
+    "@lumino/coreutils": ^2.2.0
+  checksum: 761245ab4b4895c7d4ae31f92cb593d8493ca7c14c632a01699b86028f269c330652d53374cb71793090015369e65722343188143823e7e2b48ef8f7f7781f1d
+  languageName: node
+  linkType: hard
+
 "@jupyterlab/notebook@npm:^4.2.0, @jupyterlab/notebook@npm:^4.4.0-alpha.0":
   version: 4.4.0-alpha.2
   resolution: "@jupyterlab/notebook@npm:4.4.0-alpha.2"
@@ -1852,7 +1861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/settingregistry@npm:^4.4.0-alpha.0, @jupyterlab/settingregistry@npm:^4.4.0-alpha.2, @jupyterlab/settingregistry@npm:^4.4.0-alpha.3":
+"@jupyterlab/settingregistry@npm:^4.4.0-alpha.2, @jupyterlab/settingregistry@npm:^4.4.0-alpha.3":
   version: 4.4.0-alpha.3
   resolution: "@jupyterlab/settingregistry@npm:4.4.0-alpha.3"
   dependencies:
@@ -1868,6 +1877,25 @@ __metadata:
   peerDependencies:
     react: ">=16"
   checksum: 8c384e9e25fd9cc18bed0d503090d0b74a01d1ba8c90d8fd5cfe9bcd767a509d7cee983271e1eff03ddeef58fa331724f421f9eab41bc6077072bbc01a80f625
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/settingregistry@npm:^4.4.0-beta.1":
+  version: 4.4.0-beta.1
+  resolution: "@jupyterlab/settingregistry@npm:4.4.0-beta.1"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.4.0-beta.1
+    "@jupyterlab/statedb": ^4.4.0-beta.1
+    "@lumino/commands": ^2.3.1
+    "@lumino/coreutils": ^2.2.0
+    "@lumino/disposable": ^2.1.3
+    "@lumino/signaling": ^2.1.3
+    "@rjsf/utils": ^5.13.4
+    ajv: ^8.12.0
+    json5: ^2.2.3
+  peerDependencies:
+    react: ">=16"
+  checksum: 37630b667768dc0f5ceb01a149d4f1c7bdceca85e7d83e5e5f5fbfe75781e02e351257310a43f841c291756e46891a870715c01382c56f927a3a481bed2179d3
   languageName: node
   linkType: hard
 
@@ -1894,6 +1922,19 @@ __metadata:
     "@lumino/properties": ^2.0.2
     "@lumino/signaling": ^2.1.3
   checksum: 1ca3c37e59500d01818c7eada8b3e57ce5c41c10e188a4f75938be570bb6c05530dc052cd4fd9b7dc64135ff98d642b9e6e8eb54681f5abdbf089fc6f9a0a534
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/statedb@npm:^4.4.0-beta.1":
+  version: 4.4.0-beta.1
+  resolution: "@jupyterlab/statedb@npm:4.4.0-beta.1"
+  dependencies:
+    "@lumino/commands": ^2.3.1
+    "@lumino/coreutils": ^2.2.0
+    "@lumino/disposable": ^2.1.3
+    "@lumino/properties": ^2.0.2
+    "@lumino/signaling": ^2.1.3
+  checksum: 57f67cbc2997b607bd29c0cb96a38d5215602e74caa6d776de5f34900f81b56e967843b30b298951ae10af8157c9cbf5ce9166c72dfd8295264c73846e2dbfef
   languageName: node
   linkType: hard
 
@@ -2074,7 +2115,7 @@ __metadata:
     "@jupyterlab/completer": ^4.4.0-alpha.0
     "@jupyterlab/notebook": ^4.4.0-alpha.0
     "@jupyterlab/rendermime": ^4.4.0-alpha.0
-    "@jupyterlab/settingregistry": ^4.4.0-alpha.0
+    "@jupyterlab/settingregistry": ^4.4.0-beta.1
     "@jupyterlab/ui-components": ^4.4.0-alpha.0
     "@langchain/anthropic": ^0.3.9
     "@langchain/community": ^0.3.31


### PR DESCRIPTION
This PR adds a plugin providing `ISettingConnector` token, with a `SettingConnector` able to replace the value of some fields from the settings stored on the server (replaced with '***'`).
It is available thanks to a recent change upstream in jupyterlabhttps://github.com/jupyterlab/jupyterlab/pull/17327.

Fixes #37.
Requires https://github.com/jupyterlab-contrib/jupyter-secrets-manager/pull/6 and https://github.com/jupyterlab-contrib/jupyter-secrets-manager/pull/7.

The passwords are not stored anymore in the settings, it is only stored using the `SecretsManager`. 
The previous session is restored by using the settings and the `SecretsManager`.

[record-2025-03-27_18.26.29.webm](https://github.com/user-attachments/assets/cee52c76-f98c-4742-83e5-dc1bb66be472)

### Details

It provides a new `SettingConnector`, which is basically a copy of the one from [jupyterlab](https://github.com/jupyterlab/jupyterlab/blob/main/packages/apputils-extension/src/settingconnector.ts), overriding the save method to remove the password fields. The fields to prevent from storing are populated by the setting panel itself.

When loading a provider from the registry, these fields are replaced by a value fetched from the `SecretsManager`.

It also allows to defer the loading of the provider. When the settings load the first time, it will trigger the loading of the provider in the registry. Since the providers are added to the registry in separate extensions, the settings may load before the availability of the provider. Deferring this load allows to load it as soon as the provider is added to the registry.