### PR TITLE
Update secrets manager to >=0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "@rjsf/utils": "^5.18.4",
         "@rjsf/validator-ajv8": "^5.18.4",
         "json5": "^2.2.3",
-        "jupyter-secrets-manager": "^0.2.0",
+        "jupyter-secrets-manager": "^0.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "jupyter-secrets-manager"
+    "jupyter-secrets-manager>=0.3.0"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/src/settings/utils.ts
+++ b/src/settings/utils.ts
@@ -1,4 +1,3 @@
-export const SECRETS_NAMESPACE = '@jupyterlite/ai';
 export const SECRETS_REPLACEMENT = '***';
 
 export function getSecretId(provider: string, label: string) {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -5,6 +5,14 @@ import { JSONSchema7 } from 'json-schema';
 
 import { IBaseCompleter } from './base-completer';
 
+export const PLUGIN_IDS = {
+  chat: '@jupyterlite/ai:chat',
+  chatCommandRegistry: '@jupyterlite/ai:autocompletion-registry',
+  completer: '@jupyterlite/ai:completer',
+  providerRegistry: '@jupyterlite/ai:provider-registry',
+  settingsConnector: '@jupyterlite/ai:settings-connector'
+};
+
 export interface IDict<T = any> {
   [key: string]: T;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,7 +1169,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/coreutils@npm:^6.4.0, @jupyterlab/coreutils@npm:^6.4.1":
+"@jupyterlab/coreutils@npm:^6.0.0, @jupyterlab/coreutils@npm:^6.4.0, @jupyterlab/coreutils@npm:^6.4.1":
   version: 6.4.1
   resolution: "@jupyterlab/coreutils@npm:6.4.1"
   dependencies:
@@ -1614,7 +1614,7 @@ __metadata:
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^5.0.0
     json5: ^2.2.3
-    jupyter-secrets-manager: ^0.2.0
+    jupyter-secrets-manager: ^0.3.0
     npm-run-all: ^4.1.5
     prettier: ^3.0.0
     react: ^18.2.0
@@ -5715,15 +5715,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jupyter-secrets-manager@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "jupyter-secrets-manager@npm:0.2.0"
+"jupyter-secrets-manager@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "jupyter-secrets-manager@npm:0.3.0"
   dependencies:
     "@jupyterlab/application": ^4.0.0
+    "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/statedb": ^4.0.0
     "@lumino/algorithm": ^2.0.0
     "@lumino/coreutils": ^2.1.2
-  checksum: 7745809a2b1922247b100ed36fabf8ffaa96c73b4343233ce70bfffec1ff131ac365a190e2661516642f57f9d84c6f0a834643bbbf7ebc98579ae2961bcc645f
+  checksum: 8e0b9dd4acf746c3e8383a8de2621745297f7e96a323b7a5469e9cb487d4ddf0ef36af9b716a53e85868e922dfae3632dc4a961b8c059b2b79b5a0b93f2146d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the secrets-manager to `v0.3.0`, which includes some ways to isolate the secrets between extensions.

See https://github.com/jupyterlab-contrib/jupyter-secrets-manager/pull/13 for context.

With this update, the plugin that will use the secrets needs to "sign" to the secrets manager. It will receive a unique token that will be use to manage the secrets. The token is associated to a namespace, which must be the same value as the plugin id.

The token is stored to a private namespace, to prevent other extensions to be able to retrieve it.
