### PR TITLE
Fix the API keys in provider when using the secrets manager

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -176,7 +176,9 @@ export class AIProviderRegistry implements IAIProviderRegistry {
           SECRETS_NAMESPACE,
           id
         );
-        fullSettings[key] = secrets?.value || settings[key];
+        if (secrets !== undefined) {
+          fullSettings[key] = secrets.value;
+        }
         continue;
       }
       fullSettings[key] = settings[key];

--- a/src/settings/settings-connector.ts
+++ b/src/settings/settings-connector.ts
@@ -71,12 +71,11 @@ export class SettingConnector
 
   async save(id: string, raw: string): Promise<void> {
     const settings = json5.parse(raw);
+
+    // Replace secrets fields with the replacement string.
+    // Create the field if it does not exist in settings.
     this._doNotSave.forEach(field => {
-      if (
-        settings['AIprovider'] !== undefined &&
-        settings['AIprovider'][field] !== undefined &&
-        settings['AIprovider'][field] !== ''
-      ) {
+      if (settings['AIprovider'] !== undefined) {
         settings['AIprovider'][field] = SECRETS_REPLACEMENT;
       }
     });


### PR DESCRIPTION
Fixes #66

This PR force writing an entry in settings file for each secret, even if the field has been hidden in the settings UI. The value is replaced by `"***"` in the file.
That way, the AI provider registry try to fetch these entries from the secrets manager, and set the provider with the correct secret.
