### PR TITLE
Fix completer settings

### DIFF
--- a/src/base-completer.ts
+++ b/src/base-completer.ts
@@ -9,7 +9,7 @@ export interface IBaseCompleter {
   /**
    * The LLM completer.
    */
-  provider: BaseLanguageModel;
+  completer: BaseLanguageModel;
 
   /**
    * The completion prompt.

--- a/src/default-providers/Anthropic/completer.ts
+++ b/src/default-providers/Anthropic/completer.ts
@@ -11,11 +11,11 @@ import { COMPLETION_SYSTEM_PROMPT } from '../../provider';
 
 export class AnthropicCompleter implements IBaseCompleter {
   constructor(options: BaseCompleter.IOptions) {
-    this._anthropicProvider = new ChatAnthropic({ ...options.settings });
+    this._completer = new ChatAnthropic({ ...options.settings });
   }
 
-  get provider(): BaseChatModel {
-    return this._anthropicProvider;
+  get completer(): BaseChatModel {
+    return this._completer;
   }
 
   /**
@@ -44,7 +44,7 @@ export class AnthropicCompleter implements IBaseCompleter {
     ];
 
     try {
-      const response = await this._anthropicProvider.invoke(messages);
+      const response = await this._completer.invoke(messages);
       const items = [];
 
       // Anthropic can return string or complex content, a list of string/images/other.
@@ -70,6 +70,6 @@ export class AnthropicCompleter implements IBaseCompleter {
     }
   }
 
-  private _anthropicProvider: ChatAnthropic;
+  private _completer: ChatAnthropic;
   private _prompt: string = COMPLETION_SYSTEM_PROMPT;
 }

--- a/src/default-providers/ChromeAI/completer.ts
+++ b/src/default-providers/ChromeAI/completer.ts
@@ -32,7 +32,7 @@ const CODE_BLOCK_END_REGEX = /```$/;
 
 export class ChromeCompleter implements IBaseCompleter {
   constructor(options: BaseCompleter.IOptions) {
-    this._chromeProvider = new ChromeAI({ ...options.settings });
+    this._completer = new ChromeAI({ ...options.settings });
   }
 
   /**
@@ -45,8 +45,8 @@ export class ChromeCompleter implements IBaseCompleter {
     this._prompt = value;
   }
 
-  get provider(): LLM {
-    return this._chromeProvider;
+  get completer(): LLM {
+    return this._completer;
   }
 
   async fetch(
@@ -64,7 +64,7 @@ export class ChromeCompleter implements IBaseCompleter {
     ];
 
     try {
-      let response = await this._chromeProvider.invoke(messages);
+      let response = await this._completer.invoke(messages);
 
       // ChromeAI sometimes returns a string starting with '```',
       // so process the response to remove the code block delimiters
@@ -84,6 +84,6 @@ export class ChromeCompleter implements IBaseCompleter {
     }
   }
 
-  private _chromeProvider: ChromeAI;
+  private _completer: ChromeAI;
   private _prompt: string = COMPLETION_SYSTEM_PROMPT;
 }

--- a/src/default-providers/MistralAI/completer.ts
+++ b/src/default-providers/MistralAI/completer.ts
@@ -21,10 +21,10 @@ const INTERVAL = 1000;
 
 export class CodestralCompleter implements IBaseCompleter {
   constructor(options: BaseCompleter.IOptions) {
-    this._mistralProvider = new ChatMistralAI({ ...options.settings });
+    this._completer = new ChatMistralAI({ ...options.settings });
     this._throttler = new Throttler(
       async (messages: BaseMessage[]) => {
-        const response = await this._mistralProvider.invoke(messages);
+        const response = await this._completer.invoke(messages);
         // Extract results of completion request.
         const items = [];
         if (typeof response.content === 'string') {
@@ -47,8 +47,8 @@ export class CodestralCompleter implements IBaseCompleter {
     );
   }
 
-  get provider(): BaseChatModel {
-    return this._mistralProvider;
+  get completer(): BaseChatModel {
+    return this._completer;
   }
 
   /**
@@ -82,6 +82,6 @@ export class CodestralCompleter implements IBaseCompleter {
   }
 
   private _throttler: Throttler;
-  private _mistralProvider: ChatMistralAI;
+  private _completer: ChatMistralAI;
   private _prompt: string = COMPLETION_SYSTEM_PROMPT;
 }

--- a/src/default-providers/OpenAI/completer.ts
+++ b/src/default-providers/OpenAI/completer.ts
@@ -11,11 +11,11 @@ import { COMPLETION_SYSTEM_PROMPT } from '../../provider';
 
 export class OpenAICompleter implements IBaseCompleter {
   constructor(options: BaseCompleter.IOptions) {
-    this._openAIProvider = new ChatOpenAI({ ...options.settings });
+    this._completer = new ChatOpenAI({ ...options.settings });
   }
 
-  get provider(): BaseChatModel {
-    return this._openAIProvider;
+  get completer(): BaseChatModel {
+    return this._completer;
   }
 
   /**
@@ -38,7 +38,7 @@ export class OpenAICompleter implements IBaseCompleter {
     const messages = [new SystemMessage(this._prompt), new AIMessage(prompt)];
 
     try {
-      const response = await this._openAIProvider.invoke(messages);
+      const response = await this._completer.invoke(messages);
       const items = [];
       if (typeof response.content === 'string') {
         items.push({
@@ -62,6 +62,6 @@ export class OpenAICompleter implements IBaseCompleter {
     }
   }
 
-  private _openAIProvider: ChatOpenAI;
+  private _completer: ChatOpenAI;
   private _prompt: string = COMPLETION_SYSTEM_PROMPT;
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -185,7 +185,7 @@ export class AIProviderRegistry implements IAIProviderRegistry {
     if (this._currentProvider?.completer !== undefined) {
       try {
         this._completer = new this._currentProvider.completer({
-          ...fullSettings
+          settings: fullSettings
         });
         this._completerError = '';
       } catch (e: any) {


### PR DESCRIPTION
The completer has not worked for several versions, probably since #50.
The reason is that the settings are not properly passed to the completer.

The completers expect an object containing a `settings` props, while the provider registry initialize it with the content of the settings.

https://github.com/jupyterlite/ai/blob/32a67884d09bac4da807b7b1acb86f099a0bff1c/src/base-completer.ts#L40-L42
https://github.com/jupyterlite/ai/blob/32a67884d09bac4da807b7b1acb86f099a0bff1c/src/provider.ts#L187-L189

____

1. This PR fixes it in https://github.com/jupyterlite/ai/commit/3718d4b32cf7cde480d3017c5b532ced92cb5d2c
```ts
        this._completer = new this._currentProvider.completer({
          settings: fullSettings
        });
```

2. It also homogenizes the name of the private variable in the `Completer` to `_completer` instead of `_anthropicProvider`, `chromeProvider`, ...