### PR TITLE
Better handling of default values in settings

### DIFF
--- a/src/settings/panel.tsx
+++ b/src/settings/panel.tsx
@@ -341,7 +341,21 @@ export class AiSettings extends React.Component<
    * Update the Jupyterlab settings accordingly.
    */
   private _onFormChanged = (e: IChangeEvent) => {
-    this._currentSettings = JSONExt.deepCopy(e.formData);
+    const { formData } = e;
+    Object.entries(formData).forEach(([key, value]) => {
+      if (value === undefined) {
+        const schemaProperty = this.state.schema.properties?.[
+          key
+        ] as JSONSchema7;
+        if (
+          schemaProperty.default !== undefined &&
+          schemaProperty.type === 'string'
+        ) {
+          formData[key] = '';
+        }
+      }
+    });
+    this._currentSettings = JSONExt.deepCopy(formData);
     this.saveSettingsToLocalStorage(this._currentSettings);
     this.saveSettingsToRegistry();
   };


### PR DESCRIPTION
This PR improve the handling of the default values in the settings panel.

- fix #71 by allowing empty string field when there is a default value
- related to #52 by ensuring that the fields have a unique ID
- display the fields that are modified from the default (using Jupyterlab UI)
- add a button to restore to values to default when relevant (using Jupyterlab UI)

[record-2025-05-13_18.08.23.webm](https://github.com/user-attachments/assets/daf5d9b5-9bc5-40af-9b77-111735949e4d)
