### PR TITLE
Upgrade secrets manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "@rjsf/utils": "^5.18.4",
         "@rjsf/validator-ajv8": "^5.18.4",
         "json5": "^2.2.3",
-        "jupyter-secrets-manager": "^0.3.0",
+        "jupyter-secrets-manager": "^0.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/schema/provider-registry.json
+++ b/schema/provider-registry.json
@@ -11,12 +11,6 @@
       "description": "Whether to use or not the secrets manager. If not, secrets will be stored in the browser (local storage)",
       "default": true
     },
-    "HideSecretFields": {
-      "type": "boolean",
-      "title": "Hide secret fields",
-      "description": "Whether to hide the secret fields in the UI or not",
-      "default": true
-    },
     "AIprovider": {
       "type": "object",
       "title": "AI provider",

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,9 @@ const providerRegistryPlugin: JupyterFrontEndPlugin<IAIProviderRegistry> =
       settingRegistry
         .load(providerRegistryPlugin.id)
         .then(settings => {
+          if (!secretsManager) {
+            delete settings.schema.properties?.['UseSecretsManager'];
+          }
           const updateProvider = () => {
             // Update the settings to the AI providers.
             const providerSettings = (settings.get('AIprovider').composite ?? {

--- a/src/settings/panel.tsx
+++ b/src/settings/panel.tsx
@@ -199,7 +199,7 @@ export class AiSettings extends React.Component<
     const currentSettings = { ...this._currentSettings };
     const settings = JSON.parse(localStorage.getItem(STORAGE_NAME) ?? '{}');
     // Do not save secrets in local storage if using the secrets manager.
-    if (this._secretsManager && this._useSecretsManager) {
+    if (this._useSecretsManager) {
       this._secretFields.forEach(field => delete currentSettings[field]);
     }
     settings[this._provider] = currentSettings;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,7 +1461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/settingregistry@npm:^4.4.0, @jupyterlab/settingregistry@npm:^4.4.1":
+"@jupyterlab/settingregistry@npm:^4.0.0, @jupyterlab/settingregistry@npm:^4.4.0, @jupyterlab/settingregistry@npm:^4.4.1":
   version: 4.4.1
   resolution: "@jupyterlab/settingregistry@npm:4.4.1"
   dependencies:
@@ -1614,7 +1614,7 @@ __metadata:
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^5.0.0
     json5: ^2.2.3
-    jupyter-secrets-manager: ^0.3.0
+    jupyter-secrets-manager: ^0.4.0
     npm-run-all: ^4.1.5
     prettier: ^3.0.0
     react: ^18.2.0
@@ -5677,16 +5677,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jupyter-secrets-manager@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "jupyter-secrets-manager@npm:0.3.0"
+"jupyter-secrets-manager@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "jupyter-secrets-manager@npm:0.4.0"
   dependencies:
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
+    "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/statedb": ^4.0.0
     "@lumino/algorithm": ^2.0.0
     "@lumino/coreutils": ^2.1.2
-  checksum: 8e0b9dd4acf746c3e8383a8de2621745297f7e96a323b7a5469e9cb487d4ddf0ef36af9b716a53e85868e922dfae3632dc4a961b8c059b2b79b5a0b93f2146d5
+    "@lumino/signaling": ^2.1.2
+  checksum: 1cf0399df4bc9c16e91b60d2526e32f6690b5a3b4293d5ff727ab992b49d08d172e3fba6f3d95ad97eef44b1f934d2db56823c886c47bca2fb1216e4a9b4f140
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrade `jupyter-secrets-manager` to `>=0.4.0`.

Use the secrets manager new settings to display or not the secrets fields (instead of a jupyterlite-ai setting).
That way there is only one setting to set up all the extensions using the secrets manager.
`jupyter-secrets-manager>=0.4.0` also includes a feature to lock this settings, and therefore prevents third party extension to expose the secrets fields by changing the setting.

This PR also removes the `UseSecretsManager` settings if the extension isn't activated.