### PR TITLE
Pin PyPI version of jupyter-secrets-manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "jupyter-secrets-manager>=0.3.0"
+    "jupyter-secrets-manager >=0.4,<0.5"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
Follow up #75, which only upgrades the Javascript dependencies but not PyPI.