### PR TITLE
Handle compatibility with chromeAI and WebLLM

### DIFF
--- a/src/default-providers/ChromeAI/instructions.ts
+++ b/src/default-providers/ChromeAI/instructions.ts
@@ -28,13 +28,15 @@ During the download, ChromeAI may not be available via the extension.
  */
 export async function compatibilityCheck(): Promise<string | null> {
   // Check if the browser supports the ChromeAI model
-  if (typeof window === 'undefined' || !('LanguageModel' in window)) {
+  if (
+    typeof window === 'undefined' ||
+    !('LanguageModel' in window) ||
+    window.LanguageModel === undefined ||
+    (window.LanguageModel as any).availability === undefined
+  ) {
     return 'Your browser does not support ChromeAI. Please use an updated chrome based browser like Google Chrome, and follow the instructions in settings to enable it.';
   }
   const languageModel = window.LanguageModel as any;
-  if (languageModel === undefined || languageModel.availability === undefined) {
-    return 'Your browser does not support ChromeAI. Please use a chrome based browser like Google Chrome, and follow the instructions in settings to enable it.';
-  }
   if (!(await languageModel.availability())) {
     return 'The ChromeAI model is not available in your browser. Please ensure you have enabled the necessary flags in Google Chrome as described in the instructions in settings.';
   }

--- a/src/default-providers/ChromeAI/instructions.ts
+++ b/src/default-providers/ChromeAI/instructions.ts
@@ -22,3 +22,22 @@ During the download, ChromeAI may not be available via the extension.
 
 <i class="fa fa-info-circle" aria-hidden="true"></i> For more information about Chrome Built-in AI: <https://developer.chrome.com/docs/ai/get-started>
 `;
+
+/**
+ * Check if the browser supports ChromeAI and the model is available.
+ */
+export async function compatibilityCheck(): Promise<string | null> {
+  // Check if the browser supports the ChromeAI model
+  if (typeof window === 'undefined' || !('LanguageModel' in window)) {
+    return 'Your browser does not support ChromeAI. Please use an updated chrome based browser like Google Chrome, and follow the instructions in settings to enable it.';
+  }
+  const languageModel = window.LanguageModel as any;
+  if (languageModel === undefined || languageModel.availability === undefined) {
+    return 'Your browser does not support ChromeAI. Please use a chrome based browser like Google Chrome, and follow the instructions in settings to enable it.';
+  }
+  if (!(await languageModel.availability())) {
+    return 'The ChromeAI model is not available in your browser. Please ensure you have enabled the necessary flags in Google Chrome as described in the instructions in settings.';
+  }
+  // If the model is available, return null to indicate compatibility
+  return null;
+}

--- a/src/default-providers/WebLLM/instructions.ts
+++ b/src/default-providers/WebLLM/instructions.ts
@@ -16,3 +16,18 @@ WebLLM enables running LLMs directly in your browser, making it possible to use 
 
 <i class="fas fa-exclamation-triangle"></i> Model performance depends on your device's hardware capabilities. More powerful devices will run models faster. Some larger models may not work well on devices with limited GPU memory or may experience slow response times.
 `;
+
+/**
+ * Check if the browser supports WebLLM.
+ */
+export async function compatibilityCheck(): Promise<string | null> {
+  // Check if the browser supports the ChromeAI model
+  if (typeof navigator === 'undefined' || !('gpu' in navigator)) {
+    return 'Your browser does not support WebLLM, it does not support required WebGPU.';
+  }
+  if ((await navigator.gpu.requestAdapter()) === null) {
+    return 'You may need to enable WebGPU, `await navigator.gpu.requestAdapter()` is null.';
+  }
+  // If the model is available, return null to indicate compatibility
+  return null;
+}

--- a/src/default-providers/index.ts
+++ b/src/default-providers/index.ts
@@ -28,7 +28,9 @@ import OpenAISettings from './OpenAI/settings-schema.json';
 import WebLLMSettings from './WebLLM/settings-schema.json';
 
 // Import instructions
-import ChromeAIInstructions from './ChromeAI/instructions';
+import ChromeAIInstructions, {
+  compatibilityCheck as chromeAICompatibilityCheck
+} from './ChromeAI/instructions';
 import MistralAIInstructions from './MistralAI/instructions';
 import OllamaInstructions from './Ollama/instructions';
 import WebLLMInstructions from './WebLLM/instructions';
@@ -53,7 +55,8 @@ const AIProviders: IAIProvider[] = [
     chatModel: ChromeAI,
     completer: ChromeCompleter,
     instructions: ChromeAIInstructions,
-    settingsSchema: ChromeAISettings
+    settingsSchema: ChromeAISettings,
+    compatibilityCheck: chromeAICompatibilityCheck
   },
   {
     name: 'MistralAI',

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -51,6 +51,11 @@ export interface IAIProvider {
    * Default to `(error) => error.message`.
    */
   errorMessage?: (error: any) => string;
+  /**
+   * Compatibility check function, to determine if the provider is compatible with the
+   * current environment.
+   */
+  compatibilityCheck?: () => Promise<string | null>;
 }
 
 /**
@@ -85,6 +90,12 @@ export interface IAIProviderRegistry {
    * Get the instructions of a given provider.
    */
   getInstructions(provider: string): string | undefined;
+  /**
+   * Get the compatibility check function of a given provider.
+   */
+  getCompatibilityCheck(
+    provider: string
+  ): (() => Promise<string | null>) | undefined;
   /**
    * Format an error message from the current provider.
    */

--- a/style/base.css
+++ b/style/base.css
@@ -9,3 +9,8 @@
 .jp-AISettingsInstructions {
   font-size: var(--jp-content-font-size1);
 }
+
+.jp-AISettingsError {
+  color: var(--jp-error-color1);
+  font-size: var(--jp-content-font-size1);
+}


### PR DESCRIPTION
Fixes #78.

- add a `checkCompatibility()` function in `AIProvider` interface, to check if the web browser is compatible with the provider.
- check if ChromeAI is available. If not, the provider is set to `null` and the error message in the chat is more relevant.
- check if WebLLM is available. If not, the provider is set to `null` and the error message in the chat is more relevant.

[record-2025-05-26_15.28.30.webm](https://github.com/user-attachments/assets/f504405b-24e9-4674-84e2-28a73297b134)
