### PR TITLE
Export the IAIProviderRegistry token

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -221,3 +221,5 @@ export default [
   completerPlugin,
   ...defaultProviderPlugins
 ];
+
+export { IAIProviderRegistry } from './tokens';


### PR DESCRIPTION
Required to let other extensions add their own providers to the registry.