### PR TITLE
Open the settings from the chat panel

### DIFF
--- a/src/chat-handler.ts
+++ b/src/chat-handler.ts
@@ -39,7 +39,7 @@ export const welcomeMessage = (providers: string[]) => `
 #### Ask JupyterLite AI
 
 
-The provider to use can be set in the settings editor, by selecting it from
+The provider to use can be set in the <button data-commandLinker-command="settingeditor:open" data-commandLinker-args='{"query": "AI provider"}' href="#">settings editor</button>, by selecting it from
 the <img src="${AI_AVATAR}" width="16" height="16"> _AI provider_ settings.
 
 The current providers that are available are _${providers.sort().join('_, _')}_.

--- a/style/base.css
+++ b/style/base.css
@@ -25,3 +25,21 @@
   max-width: 350px;
   margin: 0 auto;
 }
+
+.jp-chat-welcome-message button[data-commandLinker-command] {
+  background: var(--jp-layout-color2);
+  border: 1px solid var(--jp-border-color1);
+  color: var(--jp-ui-font-color1);
+  border-radius: var(--jp-border-radius);
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+  padding: 2px 6px;
+  transition: all 0.2s ease;
+}
+
+.jp-chat-welcome-message button[data-commandLinker-command]:hover {
+  background: var(--jp-layout-color3);
+  border-color: var(--jp-brand-color1);
+  color: var(--jp-brand-color1);
+}


### PR DESCRIPTION
Minor improvement to the welcome message, so users can open the settings editor directly from it:

https://github.com/user-attachments/assets/8bfca9d1-08a3-45bf-95f7-fd32cea975ef

