### PR TITLE
Fix secret fields initialization when using the secrets manager

### DIFF
--- a/src/settings/panel.tsx
+++ b/src/settings/panel.tsx
@@ -309,6 +309,10 @@ export class AiProviderSettings extends React.Component<
     this._settings.changed.connect(this._settingsChanged);
   }
 
+  componentDidMount(): void {
+    this.componentDidUpdate();
+  }
+
   async componentDidUpdate(): Promise<void> {
     if (!this._secretsManager || !this._useSecretsManager) {
       return;
@@ -398,6 +402,7 @@ export class AiProviderSettings extends React.Component<
         sanitizedSettings[field] = SECRETS_REPLACEMENT;
       });
     }
+
     this.props.aiSettings.saveSettingsToRegistry(this._role, {
       provider: this._provider,
       ...sanitizedSettings


### PR DESCRIPTION
This PR initializes the secrets fields at first loading when the secrets manager is used.

The secrets fields are attached to the secret manager when `componentDidUpdate()` method is called. According to the [documentation](https://react.dev/reference/react/Component#componentdidupdate), this method is not called on first render. 
Therefore, the secret fields were not attached to the manager before any setting is updated (before a re-rendering), which led to secrets not being saved.

This PR add a `componentDidMount()` method that calls `componentDidUpdate()`, to attach the secret fields to the manager.

Fixes #116