### PR TITLE
fix: chat placeholder in dark theme

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -10,7 +10,7 @@
   "rules": {
     "csstree/validator": true,
     "property-no-vendor-prefix": null,
-    "selector-class-pattern": "^([a-z][A-z\\d]*)(-[A-z\\d]+)*$",
+    "selector-class-pattern": "^[a-zA-Z][a-zA-Z0-9-]*$",
     "selector-no-vendor-prefix": null,
     "value-no-vendor-prefix": null
   }

--- a/style/base.css
+++ b/style/base.css
@@ -44,27 +44,27 @@
   color: var(--jp-brand-color1);
 }
 
-body[data-jp-theme-light="false"] textarea::placeholder {
+body[data-jp-theme-light='false'] textarea::placeholder {
   color: #fff0f0 !important;
 }
 
-body[data-jp-theme-light="false"] .MuiOutlinedInput-notchedOutline {
+body[data-jp-theme-light='false'] .MuiOutlinedInput-notchedOutline {
   border-color: #f1f1f1 !important;
 }
 
-body[data-jp-theme-light="false"] .MuiButton-containedPrimary.Mui-disabled {
+body[data-jp-theme-light='false'] .MuiButton-containedPrimary.Mui-disabled {
   background-color: #424040 !important;
   color: #00c3ff !important;
 }
 
-body[data-jp-theme-light="false"] textarea {
+body[data-jp-theme-light='false'] textarea {
   color: #fff !important;
 }
 
-body[data-jp-theme-light="false"] .MuiInputBase-root {
+body[data-jp-theme-light='false'] .MuiInputBase-root {
   background-color: #141414 !important;
 }
 
-body[data-jp-theme-light="false"] .MuiFormHelperText-root {
+body[data-jp-theme-light='false'] .MuiFormHelperText-root {
   color: #ececec !important;
 }


### PR DESCRIPTION
Now we can easily see the chat placeholder in the dark theme

https://github.com/user-attachments/assets/ca8d469f-b677-4bf6-8692-edb73111ec2a

