### PR TITLE
Add `jupyterlab-cell-diff`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "jupyter-secrets-manager >=0.4,<0.5"
+    "jupyter-secrets-manager >=0.4,<0.5",
+    "jupyterlab-cell-diff >=0.5.0,<0.6",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
Fixes #112 

`jupyterlab-cell-diff` exposes a `jupyterlab-cell-diff:show-codemirror` command to show diff.

The prompt is already crafted to hint the model to show diffs after specific actions:

https://github.com/jupyterlite/ai/blob/e20978c76a92eed6870621a9864890b603c9ba02/src/agent.ts#L765-L769

https://github.com/user-attachments/assets/d1df0479-2280-401b-acb9-1949b05dc85a

