### PR TITLE
Fix parameters for `discover_commands`

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -588,13 +588,19 @@ export class AgentManager {
     const toolCallId = modelEvent.toolCallId;
     const toolName = modelEvent.toolName;
     const toolInput = modelEvent.input;
+    let parsedToolInput;
+    try {
+      parsedToolInput = JSON.parse(toolInput);
+    } catch (error) {
+      parsedToolInput = {};
+    }
 
     this._agentEvent.emit({
       type: 'tool_call_start',
       data: {
         callId: toolCallId,
         toolName,
-        input: JSON.parse(toolInput)
+        input: parsedToolInput
       }
     });
   }

--- a/src/tools/commands.ts
+++ b/src/tools/commands.ts
@@ -12,7 +12,14 @@ export function createDiscoverCommandsTool(commands: CommandRegistry): ITool {
     name: 'discover_commands',
     description:
       'Discover all available JupyterLab commands with their metadata, arguments, and descriptions',
-    parameters: z.object({}),
+    parameters: z.object({
+      // currently unused, but could be used to filter commands by a search term
+      query: z
+        .string()
+        .optional()
+        .nullable()
+        .describe('Optional search query to filter commands')
+    }),
     execute: async () => {
       try {
         const commandList: Array<{


### PR DESCRIPTION
For some reasons this was triggering an error on tool call when using Claude Sonnet 4.

For now we can put a placeholder to later be able to query commands.