### PR TITLE
Custom base URL and generic provider (OpenAI compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,52 @@ Then restart Chrome for these changes to take effect.
 > [!NOTE]
 > For more information about Chrome Built-in AI: https://developer.chrome.com/docs/ai/get-started
 
+## Using LiteLLM Proxy
+
+[LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) is an OpenAI-compatible proxy server that allows you to call 100+ LLMs through a unified interface.
+
+Using LiteLLM Proxy with jupyterlite-ai provides flexibility to switch between different AI providers (OpenAI, Anthropic, Google, Azure, local models, etc.) without changing your JupyterLite configuration. It's particularly useful for enterprise deployments where the proxy can be hosted within private infrastructure to manage external API calls and keep API keys server-side.
+
+### Setting up LiteLLM Proxy
+
+1. Install LiteLLM:
+
+Follow the instructions at https://docs.litellm.ai/docs/simple_proxy.
+
+2. Create a `litellm_config.yaml` file with your model configuration:
+
+```yaml
+model_list:
+  - model_name: gpt-5
+    litellm_params:
+      model: gpt-5
+      api_key: os.environ/OPENAI_API_KEY
+
+  - model_name: claude-sonnet
+    litellm_params:
+      model: claude-sonnet-4-5-20250929
+      api_key: os.environ/ANTHROPIC_API_KEY
+```
+
+3. Start the proxy server, for example:
+
+```bash
+litellm --config litellm_config.yaml
+```
+
+The proxy will start on `http://0.0.0.0:4000` by default.
+
+### Configuring `jupyterlite-ai` to use LiteLLM Proxy
+
+1. In JupyterLab, open the AI settings panel and go to the **AI Providers** section.
+2. Select the **Generic** provider (OpenAI-compatible)
+3. Configure the following settings:
+   - **Base URL**: `http://0.0.0.0:4000` (or your proxy server URL)
+   - **Model**: The model name from your `litellm_config.yaml` (e.g., `gpt-5`, `claude-sonnet`)
+
+> [!NOTE]
+> For more information about LiteLLM Proxy configuration, see the [LiteLLM documentation](https://docs.litellm.ai/docs/simple_proxy).
+
 ## Uninstall
 
 To remove the extension, execute:

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -743,6 +743,7 @@ export class AgentManager {
     }
     const provider = activeProvider.provider;
     const model = activeProvider.model;
+    const baseURL = activeProvider.baseURL;
 
     let apiKey: string;
     if (this._secretsManager && this._settingsModel.config.useSecretsManager) {
@@ -762,7 +763,8 @@ export class AgentManager {
       {
         provider,
         model,
-        apiKey
+        apiKey,
+        baseURL
       },
       this._chatProviderRegistry
     );

--- a/src/completion/completion-provider.ts
+++ b/src/completion/completion-provider.ts
@@ -174,6 +174,7 @@ export class AICompletionProvider implements IInlineCompletionProvider {
 
     const provider = activeProvider.provider;
     const model = activeProvider.model;
+    const baseURL = activeProvider.baseURL;
 
     let apiKey: string;
     if (this._secretsManager && this._settingsModel.config.useSecretsManager) {
@@ -194,7 +195,8 @@ export class AICompletionProvider implements IInlineCompletionProvider {
         {
           provider,
           model,
-          apiKey
+          apiKey,
+          baseURL
         },
         this._completionProviderRegistry
       );

--- a/src/models/settings-model.ts
+++ b/src/models/settings-model.ts
@@ -6,7 +6,7 @@ const PLUGIN_ID = '@jupyterlite/ai:settings-model';
 export interface IProviderConfig {
   id: string;
   name: string;
-  provider: 'anthropic' | 'mistral' | 'ollama' | 'openai';
+  provider: string;
   model: string;
   apiKey?: string;
   baseURL?: string;

--- a/src/models/settings-model.ts
+++ b/src/models/settings-model.ts
@@ -6,7 +6,7 @@ const PLUGIN_ID = '@jupyterlite/ai:settings-model';
 export interface IProviderConfig {
   id: string;
   name: string;
-  provider: 'anthropic' | 'mistral' | 'ollama';
+  provider: 'anthropic' | 'mistral' | 'ollama' | 'openai';
   model: string;
   apiKey?: string;
   baseURL?: string;

--- a/src/providers/built-in-providers.ts
+++ b/src/providers/built-in-providers.ts
@@ -142,6 +142,7 @@ export function registerBuiltInChatProviders(
     supportsBaseURL: true,
     supportsHeaders: true,
     supportsToolCalling: true,
+    description: 'Uses /chat/completions endpoint',
     factory: (options: IModelOptions) => {
       const openai = createOpenAI({
         apiKey: options.apiKey || 'dummy',
@@ -324,6 +325,7 @@ export function registerBuiltInCompletionProviders(
     defaultModels: [],
     supportsBaseURL: true,
     supportsHeaders: true,
+    description: 'Uses /chat/completions endpoint',
     customSettings: {
       completionConfig: {
         temperature: 0.3,

--- a/src/providers/built-in-providers.ts
+++ b/src/providers/built-in-providers.ts
@@ -132,6 +132,28 @@ export function registerBuiltInChatProviders(
   };
 
   registry.registerProvider(ollamaInfo);
+
+  // Generic OpenAI-compatible provider
+  const genericInfo: IChatProviderInfo = {
+    id: 'generic',
+    name: 'Generic (OpenAI-compatible)',
+    requiresApiKey: false,
+    defaultModels: [],
+    supportsBaseURL: true,
+    supportsHeaders: true,
+    supportsToolCalling: true,
+    factory: (options: IModelOptions) => {
+      const openai = createOpenAI({
+        apiKey: options.apiKey || 'dummy',
+        ...(options.baseURL && { baseURL: options.baseURL }),
+        ...(options.headers && { headers: options.headers })
+      });
+      const modelName = options.model || 'gpt-4o';
+      return aisdk(openai(modelName));
+    }
+  };
+
+  registry.registerProvider(genericInfo);
 }
 
 /**
@@ -291,4 +313,32 @@ export function registerBuiltInCompletionProviders(
   };
 
   registry.registerProvider(ollamaInfo);
+
+  // Generic OpenAI-compatible provider
+  const genericCompletionInfo: ICompletionProviderInfo = {
+    id: 'generic',
+    name: 'Generic (OpenAI-compatible)',
+    requiresApiKey: false,
+    defaultModels: [],
+    supportsBaseURL: true,
+    supportsHeaders: true,
+    customSettings: {
+      completionConfig: {
+        temperature: 0.3,
+        supportsFillInMiddle: false,
+        useFilterText: true
+      }
+    },
+    factory: (options: IModelOptions) => {
+      const openai = createOpenAI({
+        apiKey: options.apiKey || 'dummy',
+        ...(options.baseURL && { baseURL: options.baseURL }),
+        ...(options.headers && { headers: options.headers })
+      });
+      const modelName = options.model || 'gpt-4o';
+      return openai(modelName);
+    }
+  };
+
+  registry.registerProvider(genericCompletionInfo);
 }

--- a/src/providers/built-in-providers.ts
+++ b/src/providers/built-in-providers.ts
@@ -149,7 +149,9 @@ export function registerBuiltInChatProviders(
         ...(options.headers && { headers: options.headers })
       });
       const modelName = options.model || 'gpt-4o';
-      return aisdk(openai(modelName));
+      // explicitly use openai.chat to ensure we use the /chat/completions endpoint
+      // for use with LiteLLM and other OpenAI-compatible providers
+      return aisdk(openai.chat(modelName));
     }
   };
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -156,6 +156,11 @@ export interface IBaseProviderInfo {
   supportsToolCalling?: boolean;
 
   /**
+   * Optional description shown in the UI
+   */
+  description?: string;
+
+  /**
    * Additional provider-specific configuration schema
    */
   customSettings?: Record<string, any>;

--- a/src/widgets/ai-settings.tsx
+++ b/src/widgets/ai-settings.tsx
@@ -621,26 +621,36 @@ const AISettingsComponent: React.FC<IAISettingsComponentProps> = ({
                   </Alert>
                 ) : (
                   <List>
-                    {config.providers.map(provider => (
-                      <ListItem key={provider.id} divider>
-                        <ListItemText
-                          primary={provider.name}
-                          secondary={
-                            <Typography variant="body2" color="text.secondary">
-                              {provider.provider} • {provider.model}
-                            </Typography>
-                          }
-                        />
-                        <ListItemSecondaryAction>
-                          <IconButton
-                            onClick={e => handleMenuClick(e, provider.id)}
-                            size="small"
-                          >
-                            <MoreVert />
-                          </IconButton>
-                        </ListItemSecondaryAction>
-                      </ListItem>
-                    ))}
+                    {config.providers.map(provider => {
+                      const providerInfo = chatProviderRegistry.getProviderInfo(
+                        provider.provider
+                      );
+                      return (
+                        <ListItem key={provider.id} divider>
+                          <ListItemText
+                            primary={provider.name}
+                            secondary={
+                              <Typography
+                                variant="body2"
+                                color="text.secondary"
+                              >
+                                {provider.provider} • {provider.model}
+                                {providerInfo?.description &&
+                                  ` • ${providerInfo.description}`}
+                              </Typography>
+                            }
+                          />
+                          <ListItemSecondaryAction>
+                            <IconButton
+                              onClick={e => handleMenuClick(e, provider.id)}
+                              size="small"
+                            >
+                              <MoreVert />
+                            </IconButton>
+                          </ListItemSecondaryAction>
+                        </ListItem>
+                      );
+                    })}
                   </List>
                 )}
               </CardContent>

--- a/src/widgets/provider-config-dialog.tsx
+++ b/src/widgets/provider-config-dialog.tsx
@@ -66,7 +66,8 @@ export const ProviderConfigDialog: React.FC<IProviderConfigDialogProps> = ({
         models: info.defaultModels,
         requiresApiKey: info.requiresApiKey,
         allowCustomModel: id === 'ollama' || id === 'generic', // Ollama and Generic allow custom models
-        supportsBaseURL: info.supportsBaseURL
+        supportsBaseURL: info.supportsBaseURL,
+        description: info.description
       };
     });
   }, [chatProviderRegistry]);
@@ -151,15 +152,22 @@ export const ProviderConfigDialog: React.FC<IProviderConfigDialogProps> = ({
             >
               {providerOptions.map(option => (
                 <MenuItem key={option.value} value={option.value}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    {option.label}
-                    {option.requiresApiKey && (
-                      <Chip
-                        size="small"
-                        label="API Key"
-                        color="default"
-                        variant="outlined"
-                      />
+                  <Box>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      {option.label}
+                      {option.requiresApiKey && (
+                        <Chip
+                          size="small"
+                          label="API Key"
+                          color="default"
+                          variant="outlined"
+                        />
+                      )}
+                    </Box>
+                    {option.description && (
+                      <Typography variant="caption" color="text.secondary">
+                        {option.description}
+                      </Typography>
                     )}
                   </Box>
                 </MenuItem>

--- a/src/widgets/provider-config-dialog.tsx
+++ b/src/widgets/provider-config-dialog.tsx
@@ -65,7 +65,7 @@ export const ProviderConfigDialog: React.FC<IProviderConfigDialogProps> = ({
         label: info.name,
         models: info.defaultModels,
         requiresApiKey: info.requiresApiKey,
-        allowCustomModel: id === 'ollama', // Only Ollama allows custom models for now
+        allowCustomModel: id === 'ollama' || id === 'generic', // Ollama and Generic allow custom models
         supportsBaseURL: info.supportsBaseURL
       };
     });

--- a/src/widgets/provider-config-dialog.tsx
+++ b/src/widgets/provider-config-dialog.tsx
@@ -65,7 +65,8 @@ export const ProviderConfigDialog: React.FC<IProviderConfigDialogProps> = ({
         label: info.name,
         models: info.defaultModels,
         requiresApiKey: info.requiresApiKey,
-        allowCustomModel: id === 'ollama' // Only Ollama allows custom models for now
+        allowCustomModel: id === 'ollama', // Only Ollama allows custom models for now
+        supportsBaseURL: info.supportsBaseURL
       };
     });
   }, [chatProviderRegistry]);
@@ -235,7 +236,7 @@ export const ProviderConfigDialog: React.FC<IProviderConfigDialogProps> = ({
             />
           )}
 
-          {(provider === 'ollama' || selectedProvider?.allowCustomModel) && (
+          {selectedProvider?.supportsBaseURL && (
             <TextField
               fullWidth
               label="Base URL (Optional)"
@@ -249,7 +250,7 @@ export const ProviderConfigDialog: React.FC<IProviderConfigDialogProps> = ({
               helperText={
                 provider === 'ollama'
                   ? 'Ollama server endpoint'
-                  : 'Custom API base URL if needed'
+                  : 'Custom API base URL (e.g., for LiteLLM proxy). Leave empty to use default provider endpoint.'
               }
             />
           )}


### PR DESCRIPTION
Fixes https://github.com/jupyterlite/ai/issues/144

- Allow providing a custom baser URL when configuring providers
- Add a new generic provider (OpenAI compatible)

<img width="1792" height="1144" alt="image" src="https://github.com/user-attachments/assets/9ff2ea35-3c93-44d4-8232-7f1df6f3a6bc" />




For example this allows using the LiteLLM simple proxy (https://docs.litellm.ai/docs/simple_proxy) with the generic OpenAI compatible provider: 




https://github.com/user-attachments/assets/2c0433e0-f806-48e3-b4cf-43861a1c5a59


