### PR TITLE
Add UI tests for remote MCP servers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Ollama with a small model
         uses: pydantic/ollama-action@v3
         with:
-          model: qwen2:0.5b
+          model: qwen2.5:0.5b
 
       - name: Install tests dependencies
         working-directory: ui-tests

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ Untitled*.ipynb
 # Integration tests
 ui-tests/test-results/
 ui-tests/playwright-report/
+
+# LiteLLM config
+litellm_config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ jupyter = [
     "jupyterlite>=0.6.0a0",
     "notebook>=7.4.0"
 ]
+test = [
+    "fastmcp>=2.12.4,<3",
+    "starlette>=0.48.0,<0.49",
+]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/ui-tests/mcp-server.py
+++ b/ui-tests/mcp-server.py
@@ -1,0 +1,24 @@
+from fastmcp import FastMCP
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+
+mcp = FastMCP("My Server")
+
+
+@mcp.tool
+def process_data(input: str) -> str:
+    """Process data on the server"""
+    return f"Processed: {input}"
+
+
+custom_middleware = [
+    Middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    ),
+]
+
+app = mcp.http_app(middleware=custom_middleware, stateless_http=True)

--- a/ui-tests/mcp-server.py
+++ b/ui-tests/mcp-server.py
@@ -1,6 +1,7 @@
 from fastmcp import FastMCP
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
+from starlette.responses import JSONResponse
 
 mcp = FastMCP("My Server")
 
@@ -9,6 +10,11 @@ mcp = FastMCP("My Server")
 def process_data(input: str) -> str:
     """Process data on the server"""
     return f"Processed: {input}"
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request):
+    return JSONResponse({"status": "healthy", "service": "mcp-server"})
 
 
 custom_middleware = [

--- a/ui-tests/playwright.config.js
+++ b/ui-tests/playwright.config.js
@@ -5,10 +5,19 @@ const baseConfig = require('@jupyterlab/galata/lib/playwright-config');
 
 module.exports = {
   ...baseConfig,
-  webServer: {
-    command: 'jlpm start',
-    url: 'http://localhost:8888/lab',
-    timeout: 120 * 1000,
-    reuseExistingServer: !process.env.CI
-  }
+  webServer: [
+    {
+      command: 'jlpm start',
+      url: 'http://localhost:8888/lab',
+      timeout: 120 * 1000,
+      reuseExistingServer: !process.env.CI
+    },
+    {
+      command: 'uvicorn mcp-server:app --host 0.0.0.0 --port 8765',
+      url: 'http://localhost:8765/health',
+      timeout: 30 * 1000,
+      reuseExistingServer: !process.env.CI,
+      cwd: __dirname
+    }
+  ]
 };

--- a/ui-tests/tests/chat-panel.spec.ts
+++ b/ui-tests/tests/chat-panel.spec.ts
@@ -3,14 +3,13 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import { expect, galata, test } from '@jupyterlab/galata';
 import {
-  expect,
-  galata,
-  IJupyterLabPageFixture,
-  test
-} from '@jupyterlab/galata';
-import { Locator } from '@playwright/test';
-import { DEFAULT_SETTINGS_MODEL_SETTINGS } from './test-utils';
+  CHAT_PANEL_ID,
+  CHAT_PANEL_TITLE,
+  DEFAULT_SETTINGS_MODEL_SETTINGS,
+  openChatPanel
+} from './test-utils';
 
 test.use({
   mockSettings: {
@@ -24,21 +23,7 @@ test.use({
   }
 });
 
-const CHAT_PANEL_ID = '@jupyterlite/ai:chat-wrapper';
-
-const CHAT_PANEL_TITLE = 'Chat with AI assistant';
-
 const NOT_CONFIGURED_TEXT = 'Please configure your AI settings first';
-
-async function openChatPanel(page: IJupyterLabPageFixture): Promise<Locator> {
-  const panel = page.locator(`[id="${CHAT_PANEL_ID}"]`);
-  if (!(await panel.isVisible())) {
-    const chatIcon = page.getByTitle(CHAT_PANEL_TITLE).filter();
-    await chatIcon.click();
-    await page.waitForCondition(() => panel.isVisible());
-  }
-  return panel;
-}
 
 test.describe('#withoutModel', () => {
   test('should contain the chat panel icon', async ({ page }) => {

--- a/ui-tests/tests/mcp-integration.spec.ts
+++ b/ui-tests/tests/mcp-integration.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, galata, test } from '@jupyterlab/galata';
+import { DEFAULT_SETTINGS_MODEL_SETTINGS, openChatPanel } from './test-utils';
+
+const MCP_SERVER_PORT = 8765;
+const MCP_SERVER_URL = `http://0.0.0.0:${MCP_SERVER_PORT}/mcp`;
+
+test.use({
+  mockSettings: {
+    ...galata.DEFAULT_SETTINGS,
+    '@jupyterlab/apputils-extension:notification': {
+      checkForUpdates: false,
+      fetchNews: 'false',
+      doNotDisturbMode: true
+    },
+    '@jupyterlite/ai:settings-model': {
+      ...DEFAULT_SETTINGS_MODEL_SETTINGS['@jupyterlite/ai:settings-model'],
+      toolsEnabled: true,
+      // To nudge the (relatively small) model to call the tools
+      systemPrompt: 'Just call the tools you are asked to call',
+      mcpServers: [
+        {
+          id: 'test-mcp-server',
+          name: 'Test MCP Server',
+          url: MCP_SERVER_URL,
+          enabled: true
+        }
+      ]
+    }
+  }
+});
+
+const PROMPT = 'Use the process_data tool to process the text "hello world"';
+
+test.describe('#mcpIntegration', () => {
+  test('should display tool call from MCP server', async ({ page }) => {
+    test.setTimeout(120 * 1000);
+
+    const panel = await openChatPanel(page);
+    const input = panel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const sendButton = panel.locator(
+      '.jp-chat-input-container .jp-chat-send-button'
+    );
+
+    await input.pressSequentially(PROMPT);
+    await sendButton.click();
+
+    await expect(
+      panel.locator('.jp-chat-message-header:has-text("Jupyternaut")')
+    ).toHaveCount(1, { timeout: 60000 });
+
+    // Wait for tool call to appear
+    const toolCall = panel.locator('.jp-ai-tool-call');
+    await expect(toolCall).toHaveCount(1, { timeout: 30000 });
+
+    await expect(
+      panel.locator('.jp-chat-message-header:has-text("Jupyternaut")')
+    ).toHaveCount(1, { timeout: 60000 });
+    await expect(toolCall).toContainText('process_data');
+    await expect(toolCall).toContainText('Processed: hello world');
+  });
+});

--- a/ui-tests/tests/test-utils.ts
+++ b/ui-tests/tests/test-utils.ts
@@ -3,6 +3,9 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import { IJupyterLabPageFixture } from '@jupyterlab/galata';
+import { Locator } from '@playwright/test';
+
 export const DEFAULT_SETTINGS_MODEL_SETTINGS = {
   '@jupyterlite/ai:settings-model': {
     activeProvider: 'ollama-1759407012872',
@@ -10,9 +13,9 @@ export const DEFAULT_SETTINGS_MODEL_SETTINGS = {
     providers: [
       {
         id: 'ollama-1759407012872',
-        name: 'Qwen2',
+        name: 'Qwen2.5',
         provider: 'ollama',
-        model: 'qwen2:0.5b'
+        model: 'qwen2.5:0.5b'
       }
     ],
     showTokenUsage: false,
@@ -21,3 +24,19 @@ export const DEFAULT_SETTINGS_MODEL_SETTINGS = {
     useSecretsManager: false
   }
 };
+
+export const CHAT_PANEL_ID = '@jupyterlite/ai:chat-wrapper';
+
+export const CHAT_PANEL_TITLE = 'Chat with AI assistant';
+
+export async function openChatPanel(
+  page: IJupyterLabPageFixture
+): Promise<Locator> {
+  const panel = page.locator(`[id="${CHAT_PANEL_ID}"]`);
+  if (!(await panel.isVisible())) {
+    const chatIcon = page.getByTitle(CHAT_PANEL_TITLE).filter();
+    await chatIcon.click();
+    await page.waitForCondition(() => panel.isVisible());
+  }
+  return panel;
+}


### PR DESCRIPTION
Expand on #67 

- [x] Add a test `mcp-server.py` which can be used for testing
- [x] Add UI tests for remote MCP servers
- [x] Use `qwen2.5:0.5B` in the UI tests since it supports tool calls: https://ollama.com/library/qwen2.5

