### PR TITLE
Copy the keys to secrets manager when switching

### DIFF
--- a/src/widgets/ai-settings.tsx
+++ b/src/widgets/ai-settings.tsx
@@ -325,9 +325,7 @@ const AISettingsComponent: React.FC<IAISettingsComponentProps> = ({
     // Retrieve the API key from the secrets manager if necessary.
     if (model.config.useSecretsManager && secretsManager) {
       provider.apiKey =
-        (await getSecretFromManager(provider.provider, 'apiKey')) ??
-        provider.apiKey ??
-        '';
+        (await getSecretFromManager(provider.provider, 'apiKey')) ?? '';
     }
     setEditingProvider(provider);
     setDialogOpen(true);


### PR DESCRIPTION
This PR fixes an issue raised in https://github.com/jupyterlite/ai/pull/200#issue-3518865512.

When switching the setting to use the secrets manager, the API keys stored in the settings are replaced with '***', and we expect the secrets manager to have the keys. If not, we'll have to type them again.

With this PR, switching to use the secrets manager check if their is already an associate key in the secrets manager, and if not set the current one their. That way, the secrets is not lost.

It also fixes:
- display the alert when the secrets manager is on (instead of off) to advertise of not using it
- never populate the API key field with the value from setting when using the secrets manager. This avoid having '***' in this field if the API key is not in the manager.