### PR TITLE
Fixing attachments attaches to old messages bug

### DIFF
--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -138,7 +138,7 @@ export class AIChatModel extends AbstractChatModel {
       time: Date.now() / 1000,
       type: 'msg',
       raw_time: false,
-      attachments: this.input.attachments
+      attachments: [...this.input.attachments]
     };
     this.messageAdded(userMessage);
 


### PR DESCRIPTION

Now we Clone the attachments array when creating a new message

https://github.com/user-attachments/assets/5cf2e10a-2949-404f-a872-488f224d8410

- Closes #207 

CC @jtpio and @brichet 