### PR TITLE
Making Ai Agent able to Reading content for attached cells

### DIFF
--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -626,6 +626,11 @@ ${toolsList}
         return null;
       }
 
+      const kernelLang =
+        model.content?.metadata?.language_info?.name ||
+        model.content?.metadata?.kernelspec?.language ||
+        'text';
+
       const selectedCells = attachment.cells
         .map(cellInfo => {
           const cell = model.content.cells.find(
@@ -637,7 +642,9 @@ ${toolsList}
 
           const code = cell.source || '';
           const cellType = cell.cell_type;
-          return `**Cell [${cellInfo.id}] (${cellType}):**\n\`\`\`${cellType === 'code' ? 'python' : ''}\n${code}\n\`\`\``;
+          const lang = cellType === 'code' ? kernelLang : cellType;
+
+          return `**Cell [${cellInfo.id}] (${cellType}):**\n\`\`\`${lang}\n${code}\n\`\`\``;
         })
         .filter(Boolean)
         .join('\n\n');


### PR DESCRIPTION
Now our Ai Agent can easily able to read content of any notebook cells attached in chat. 

### Before

In this screen recording we can see as i share 3rd cell but we get colors list of 1st cell.

https://github.com/user-attachments/assets/44e0f898-ccc1-42e5-a3f6-b5c2035e2d21



### After

In this we can see i am sharing 3rd cell and get color list of same 3rd cell.

https://github.com/user-attachments/assets/4240f764-2fcc-42be-aca6-3219b1d8635d

- Closes #170

CC @jtpio and @brichet 

