### PR TITLE
Restore `strictNullChecks`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "rootDir": "src",
     "skipLibCheck": true,
     "strict": true,
+    "strictNullChecks": true,
     "target": "ES2022",
     "typeRoots": ["./node_modules/@types", "./src/types"]
   },


### PR DESCRIPTION
This was removed by mistake in jupyterlite/ai#214