### PR TITLE
Avoid opening a chat if the expected provider is not in settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -505,6 +505,11 @@ function registerCommands(
       execute: async (args): Promise<boolean> => {
         const area = (args.area as string) === 'main' ? 'main' : 'side';
         const provider = (args.provider as string) ?? undefined;
+
+        // Do not open the chat if the provider in args does not exists in settings.
+        if (provider && !settingsModel.getProvider(provider)) {
+          return false;
+        }
         const model = modelRegistry.createModel(
           args.name ? (args.name as string) : undefined,
           provider


### PR DESCRIPTION
Do not open the chat if the `provider` argument of the `open-chat` command doesn't exist in the settings.

Before this PR, the chat was opened with `No provider`.
This led to an unexpected behavior with the chat restoration in some corner case.

### Fixed situation

- Let's say there is one provider in settings (`provider-1`), and one chat opened with this provider
- The settings are updated from a third party application:
  - `provider-1` removed 
  - `provider-2` created and set by default
- on the next restoration, the restorer try to restore the chat with `provider-1`

**BEFORE the PR**: `provider-1` doesn't exist, so a chat without provider is created, and there is no chat created with the new default provider (`provider-2`) because a chat already exist. 

**AFTER the PR**: no chat is created because `provider-1` doesn't exist anymore in settings, and a default chat is created with `provider-2`.