### PR TITLE
Getting all chats in list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -384,8 +384,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
       widget.disposed.connect(() => {
         // Dispose of the approval buttons widget when the chat is disposed.
         approvalButton.dispose();
-        // Remove the model from the registry when the widget is disposed.
-        modelRegistry.remove(model.name);
       });
     });
 
@@ -528,11 +526,6 @@ function registerCommands(
       model.agentManager.activeProviderChanged.connect(() =>
         tracker.save(widget)
       );
-
-      // Remove the model from the registry when the widget is disposed.
-      widget.disposed.connect(() => {
-        modelRegistry.remove(model.name);
-      });
     };
 
     commands.addCommand(CommandIds.openChat, {


### PR DESCRIPTION
Getting the list of all chats in the `Open a chat` drop-down like as same as we get in `@jupyter-chat`.

https://github.com/user-attachments/assets/428b9310-d66f-4bba-b5fe-947931b4c1af


Now this PR also disables the disposing of chat model when chat is closed or moved to main area.

https://github.com/user-attachments/assets/8f1619e4-d0bf-4c51-9a0c-c0a83c36350f


- Closes #194 

cc @brichet @jtpio 
