### PR TITLE
Configure artifact retention for GitHub Pages demo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/upload-pages-artifact@v4
         with:
           path: ./demo/dist
+          retention-days: 7
 
   deploy:
     needs: build


### PR DESCRIPTION
Follow-up to #247 

So it's easier to download and try the built GitHub Pages locally.