### PR TITLE
Export the Jupyternaut icon

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -911,3 +911,4 @@ export default [
 
 // Export extension points for other extensions to use
 export * from './tokens';
+export * from './icons';


### PR DESCRIPTION
So it can be reused in other extensions.