### PR TITLE
Fix `maxOutputTokens` in the settings

### DIFF
--- a/schema/settings-model.json
+++ b/schema/settings-model.json
@@ -41,7 +41,7 @@
                 "maximum": 2,
                 "default": 0.7
               },
-              "maxTokens": {
+              "maxOutputTokens": {
                 "type": "number",
                 "description": "Maximum tokens for chat responses",
                 "minimum": 1


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlite/ai/pull/245

Align the schema definition with what is actually being used in the code.

For reference `maxTokens` was renamed in AI SDK v5: https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0#ai-sdk-core-changes