### PR TITLE
Drop python 3.9 and add 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,12 +57,15 @@ jobs:
   test_isolated:
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.14']
 
     steps:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: ${{ matrix.python-version }}
         architecture: 'x64'
     - uses: actions/download-artifact@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyterlite_ai"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
@@ -16,13 +16,13 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-
+    "Programming Language :: Python :: 3.14"
 ]
+
 dependencies = [
     "jupyter-secrets-manager >=0.5,<0.6",
     "jupyterlab-ai-commands >=0.2.1,<0.3",


### PR DESCRIPTION
This PR drops python 3.9 since it is in end of life, and include python 3.14.

It also updates the workflow installing the built package to use min and max versions (3.10 and 3.14).