### PR TITLE
Fix the attachment of the secrets field to the secrets manager

### DIFF
--- a/src/widgets/provider-config-dialog.tsx
+++ b/src/widgets/provider-config-dialog.tsx
@@ -138,7 +138,6 @@ export const ProviderConfigDialog: React.FC<IProviderConfigDialogProps> = ({
   handleSecretField,
   trans
 }) => {
-  const apiKeyRef = React.useRef<HTMLInputElement>();
   const [name, setName] = React.useState(initialConfig?.name || '');
   const [provider, setProvider] = React.useState(
     initialConfig?.provider || 'anthropic'
@@ -225,13 +224,14 @@ export const ProviderConfigDialog: React.FC<IProviderConfigDialogProps> = ({
     }
   }, [provider, selectedProvider, model]);
 
-  React.useEffect(() => {
-    // Attach the API key field to the secrets manager, to automatically save the value
-    // when it is updated.
-    if (open && apiKeyRef.current) {
-      handleSecretField(apiKeyRef.current, provider, 'apiKey');
-    }
-  }, [provider, handleSecretField, apiKeyRef.current]);
+  const handleRef = React.useCallback(
+    (node: HTMLInputElement | null) => {
+      if (open && node) {
+        handleSecretField(node, provider, 'apiKey');
+      }
+    },
+    [provider, handleSecretField, open]
+  );
 
   const updateCustomSetting = React.useCallback(
     (section: 'webSearch' | 'webFetch', key: string, value: unknown) => {
@@ -526,7 +526,7 @@ export const ProviderConfigDialog: React.FC<IProviderConfigDialogProps> = ({
             selectedProvider?.apiKeyRequirement !== 'none' && (
               <TextField
                 fullWidth
-                inputRef={apiKeyRef}
+                inputRef={handleRef}
                 label={
                   selectedProvider?.apiKeyRequirement === 'required'
                     ? trans.__('API Key')


### PR DESCRIPTION
This PR fixes the attachment of the secret field to the secrets manager (see https://github.com/jupyterlite/ai/pull/286#issuecomment-4030410981 for reference).

**Before** this PR, it was not possible to change the API key of a provider several times in a row, we needed to open the settings of another provider first.

[before.webm](https://github.com/user-attachments/assets/b8ab452b-785e-4c65-82a0-250687c29ae7)

**After**

[after.webm](https://github.com/user-attachments/assets/d27b8e3a-b7a7-4f41-a9cd-f836c0d91169)

