### PR TITLE
Update the list of available chats by listening to settings changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -566,6 +566,13 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
       });
     });
 
+    /**
+     * Update the available chat list when settings config changed.
+     */
+    settingsModel.stateChanged.connect(() => {
+      chatPanel.updateChatList();
+    });
+
     app.shell.add(chatPanel, 'left', { rank: 1000 });
 
     if (restorer) {


### PR DESCRIPTION
Listen to the settings changes to update the available chats list in the side panel.

Fix #305 