### PR TITLE
Pin fakeredis<0.35.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           set -eux
           pip install "jupyterlab>=4.5.0"
+          pip install "fakeredis<2.35.0"
           pip install -e ".[test]"
 
       - name: Setup Ollama

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           set -eux
           pip install "jupyterlab>=4.5.0"
+          # TODO: remove when fixed upstream: https://github.com/chrisguidry/docket/issues/388
           pip install "fakeredis<2.35.0"
           pip install -e ".[test]"
 


### PR DESCRIPTION
Pin `fakeredis` dependency to avoid UI tests failing with 
`ImportError: cannot import name 'FakeConnection' from 'fakeredis.aioredis' (/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/fakeredis/aioredis.py). Did you mean: '_connection'?`

It seems that we depend on it from `docket`, there is an issue about that https://github.com/chrisguidry/docket/issues/388.

Related commit, not released yet https://github.com/cunla/fakeredis-py/commit/b815645d2db2087df72af0c960fb29eaca2ebf97