### PR TITLE
Align plugin token naming

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -102,7 +102,7 @@ export interface IToolRegistry {
  * The tool registry token.
  */
 export const IToolRegistry = new Token<IToolRegistry>(
-  '@jupyterlite/ai:tool-registry',
+  '@jupyterlite/ai:IToolRegistry',
   'Tool registry for AI agent functionality'
 );
 
@@ -145,7 +145,7 @@ export interface ISkillRegistry {
  * The skill registry token.
  */
 export const ISkillRegistry = new Token<ISkillRegistry>(
-  '@jupyterlite/ai:skill-registry',
+  '@jupyterlite/ai:ISkillRegistry',
   'Skill registry for AI agent functionality'
 );
 
@@ -311,7 +311,7 @@ export interface IProviderRegistry {
  * Token for the provider registry.
  */
 export const IProviderRegistry = new Token<IProviderRegistry>(
-  '@jupyterlite/ai:provider-registry',
+  '@jupyterlite/ai:IProviderRegistry',
   'Registry for AI providers'
 );
 
@@ -608,7 +608,7 @@ export interface IAgentManager {
  * Token for the agent manager.
  */
 export const IAgentManager = new Token<IAgentManager>(
-  '@jupyterlite/ai:agent-manager'
+  '@jupyterlite/ai:IAgentManager'
 );
 
 /* The AGENT MANAGER FACTORY */
@@ -640,7 +640,7 @@ export interface IAgentManagerFactory {
  * Token for the agent manager factory.
  */
 export const IAgentManagerFactory = new Token<IAgentManagerFactory>(
-  '@jupyterlite/ai:agent-manager-factory'
+  '@jupyterlite/ai:IAgentManagerFactory'
 );
 
 /* THE CHAT MODELS HANDLER */
@@ -685,7 +685,7 @@ export interface ICreateChatOptions {
  * Token for the chat model handler.
  */
 export const IChatModelHandler = new Token<IChatModelHandler>(
-  '@jupyterlite/ai:chat-model-handler'
+  '@jupyterlite/ai:IChatModelHandler'
 );
 
 /* THE DIFF MANAGER */
@@ -760,7 +760,7 @@ export interface IDiffManager {
  * Token for the diff manager.
  */
 export const IDiffManager = new Token<IDiffManager>(
-  '@jupyterlite/ai:diff-manager'
+  '@jupyterlite/ai:IDiffManager'
 );
 
 /**


### PR DESCRIPTION
closes #311 

This PR updates plugin token naming to match the common upstream convention for consistency