### PR TITLE
Specify chat file format (backup) when fetching content

### DIFF
--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -376,7 +376,7 @@ export class AIChatModel extends AbstractChatModel {
       return false;
     }
     const contentModel = await this._contentsManager
-      .get(filepath, { content: true })
+      .get(filepath, { content: true, type: 'file', format: 'text' })
       .catch(() => {
         if (!silent) {
           console.log(`There is no backup for chat '${this.name}'`);
@@ -386,9 +386,12 @@ export class AIChatModel extends AbstractChatModel {
     if (!contentModel) {
       return false;
     }
-    const content = JSON.parse(
-      contentModel.content
-    ) as AIChatModel.ExportedChat;
+    let content: AIChatModel.ExportedChat;
+    try {
+      content = JSON.parse(contentModel.content);
+    } catch (e) {
+      throw `Error when parsing the chat ${filepath}\n${e}`;
+    }
 
     if (content.metadata?.provider) {
       if (this._settingsModel.getProvider(content.metadata.provider)) {


### PR DESCRIPTION
Some contents manager may use 'base64' as default format, which ends up as an error when trying to parse the JSON content.

This PR specify the type and format of the content when fetching it.