### PR TITLE
Await for chat messages to be cleared before setting history

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -506,12 +506,13 @@ export class AgentManager implements IAgentManager {
     this._pendingApprovals.clear();
 
     // Convert chat messages to model messages
-    const modelMessages = messages.map(msg => {
-      const isAIMessage = msg.sender.username === 'ai-assistant';
+    const modelMessages: ModelMessage[] = messages.map(msg => {
+      const role =
+        msg.sender.username === 'ai-assistant' ? 'assistant' : 'user';
       return {
-        role: isAIMessage ? 'assistant' : 'user',
+        role,
         content: msg.body
-      } as ModelMessage;
+      };
     });
     this._history = Private.sanitizeModelMessages(modelMessages);
   }

--- a/src/chat-commands/clear.ts
+++ b/src/chat-commands/clear.ts
@@ -29,7 +29,7 @@ export class ClearCommandProvider implements IChatCommandProvider {
     const context = inputModel.chatContext as
       | AIChatModel.IAIChatContext
       | undefined;
-    context?.clearMessages?.();
+    await context?.clearMessages?.();
 
     inputModel.value = '';
     inputModel.clearAttachments();

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -249,7 +249,7 @@ export class AIChatModel extends AbstractChatModel {
   clearMessages = async (): Promise<void> => {
     this.messagesDeleted(0, this.messages.length);
     this._toolContexts.clear();
-    this._agentManager.clearHistory();
+    await this._agentManager.clearHistory();
   };
 
   /**

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -32,9 +32,9 @@ import { Debouncer } from '@lumino/polling';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
-import { AI_AVATAR } from './icons';
-
 import type { UserContent, ImagePart, FilePart } from 'ai';
+
+import { AI_AVATAR } from './icons';
 
 import type { IAgentManager, IAISettingsModel, ITokenUsage } from './tokens';
 
@@ -246,7 +246,7 @@ export class AIChatModel extends AbstractChatModel {
   /**
    * Clears all messages from the chat and resets conversation state.
    */
-  clearMessages = (): void => {
+  clearMessages = async (): Promise<void> => {
     this.messagesDeleted(0, this.messages.length);
     this._toolContexts.clear();
     this._agentManager.clearHistory();
@@ -429,7 +429,7 @@ export class AIChatModel extends AbstractChatModel {
         attachments
       };
     });
-    this.clearMessages();
+    await this.clearMessages();
     this.messagesInserted(0, messages);
     this._agentManager.setHistory(messages);
     this.autosave = content.metadata?.autosave ?? false;

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -1429,7 +1429,7 @@ export namespace AIChatModel {
     /**
      * The clear messages callback.
      */
-    clearMessages: () => void;
+    clearMessages: () => Promise<void>;
     /**
      * Adds an assistant/system message to the chat.
      */

--- a/src/components/clear-button.tsx
+++ b/src/components/clear-button.tsx
@@ -16,7 +16,7 @@ export interface IClearButtonProps
   /**
    * The function to clear messages.
    */
-  clearMessages: () => void;
+  clearMessages: () => Promise<void>;
   /**
    * The application language translator.
    */
@@ -53,8 +53,8 @@ export function clearItem(
   return {
     element: (props: InputToolbarRegistry.IToolbarItemProps) => {
       const { model } = props;
-      const clearMessages = () =>
-        (model.chatContext as AIChatModel.IAIChatContext).clearMessages();
+      const clearMessages = async () =>
+        await (model.chatContext as AIChatModel.IAIChatContext).clearMessages();
       const clearProps: IClearButtonProps = {
         ...props,
         clearMessages,

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -584,7 +584,7 @@ export interface IAgentManager {
   /**
    * Clears conversation history and resets agent state.
    */
-  clearHistory(): void;
+  clearHistory(): Promise<void>;
   /**
    * Sets the conversation history with a list of messages from the chat.
    * @param messages The chat messages to set as history


### PR DESCRIPTION
Follow up #303, the `clearMessages` method was not properly awaited, and the newly added history was cleared as well.

My bad, these changes have been suggested [here](https://github.com/jupyterlite/ai/pull/290#discussion_r2947529030), but back then, the clear messages method wasn't used that way...

