### PR TITLE
Chat model title

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -706,6 +706,7 @@ export class AgentManager implements IAgentManager {
         model,
         messages
       });
+      this._updateTokenUsage(result.totalUsage, result.totalUsage.inputTokens);
       return result.text;
     } catch (e) {
       throw `Error while getting the topic of the chat\n${e}`;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -4,6 +4,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { PromiseDelegate } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import {
+  generateText,
   ToolLoopAgent,
   type ModelMessage,
   type LanguageModel,
@@ -691,6 +692,23 @@ export class AgentManager implements IAgentManager {
     } finally {
       this._controller = null;
       this._streaming.resolve();
+    }
+  }
+
+  /**
+   * Create a transient language model to request a text response which won't be added to history.
+   * @param messages - the messages sequence to send to the model.
+   */
+  async textResponse(messages: ModelMessage[]): Promise<string> {
+    try {
+      const model = await this._createModel();
+      const result = await generateText({
+        model,
+        messages
+      });
+      return result.text;
+    } catch (e) {
+      throw `Error while getting the topic of the chat\n${e}`;
     }
   }
 

--- a/src/chat-model-handler.ts
+++ b/src/chat-model-handler.ts
@@ -29,7 +29,8 @@ export class ChatModelHandler implements IChatModelHandler {
   }
 
   createModel(options: ICreateChatOptions): AIChatModel {
-    const { name, activeProvider, tokenUsage, messages, autosave } = options;
+    const { name, activeProvider, tokenUsage, messages, autosave, title } =
+      options;
 
     // Create Agent Manager first so it can be shared
     const agentManager = this._agentManagerFactory.createAgent({
@@ -57,6 +58,10 @@ export class ChatModelHandler implements IChatModelHandler {
     model.autosave = autosave ?? false;
 
     model.name = name;
+
+    if (title) {
+      model.title = title;
+    }
 
     return model;
   }

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -470,7 +470,7 @@ export class AIChatModel extends AbstractChatModel {
       {
         role: 'system',
         content:
-          'Generate a short title (max 10 words without formatting) for the following conversation. The title should reflect the first or the most representative expectation from the user.'
+          "Generate a concise title (no more than 10 words) for the following conversation. Do not use formatting. Focus on the user's main intent."
       },
       {
         role: 'user',

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -120,6 +120,11 @@ export class AIChatModel extends AbstractChatModel {
   }
 
   /**
+   * The title of the chat.
+   */
+  title: string | null = null;
+
+  /**
    * Override the getter/setter of the name to add a signal when renaming a chat.
    */
   get name(): string {
@@ -433,6 +438,7 @@ export class AIChatModel extends AbstractChatModel {
     this.messagesInserted(0, messages);
     this._agentManager.setHistory(messages);
     this.autosave = content.metadata?.autosave ?? false;
+    this.title = content.metadata?.title ?? null;
     return true;
   };
 
@@ -485,7 +491,8 @@ export class AIChatModel extends AbstractChatModel {
       attachments,
       metadata: {
         provider,
-        autosave: this.autosave
+        autosave: this.autosave,
+        ...(this.title ? { title: this.title } : {})
       }
     };
   }
@@ -1468,6 +1475,10 @@ export namespace AIChatModel {
        * Whether the chat is automatically saved.
        */
       autosave?: boolean;
+      /**
+       * An optional title of the chat.
+       */
+      title?: string;
     };
   };
 }

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -120,11 +120,6 @@ export class AIChatModel extends AbstractChatModel {
   }
 
   /**
-   * The title of the chat.
-   */
-  title: string | null = null;
-
-  /**
    * Override the getter/setter of the name to add a signal when renaming a chat.
    */
   get name(): string {
@@ -139,6 +134,31 @@ export class AIChatModel extends AbstractChatModel {
       this.restore(filepath, true);
     }
     this.setReady();
+  }
+
+  /**
+   * A signal emitting when the chat name has changed.
+   */
+  get nameChanged(): ISignal<AIChatModel, string> {
+    return this._nameChanged;
+  }
+
+  /**
+   * The title of the chat.
+   */
+  get title(): string | null {
+    return this._title;
+  }
+  set title(value: string | null) {
+    this._title = value;
+    this._titleChanged.emit(this._title);
+  }
+
+  /**
+   * A signal emitting when the chat title has changed.
+   */
+  get titleChanged(): ISignal<AIChatModel, string | null> {
+    return this._titleChanged;
   }
 
   /**
@@ -177,13 +197,6 @@ export class AIChatModel extends AbstractChatModel {
    */
   get autosaveChanged(): ISignal<AIChatModel, boolean> {
     return this._autosaveChanged;
-  }
-
-  /**
-   * A signal emitting when the chat name has changed.
-   */
-  get nameChanged(): ISignal<AIChatModel, string> {
-    return this._nameChanged;
   }
 
   /**
@@ -916,6 +929,8 @@ export class AIChatModel extends AbstractChatModel {
   private _autosave: boolean = false;
   private _autosaveChanged = new Signal<AIChatModel, boolean>(this);
   private _autosaveDebouncer: Debouncer;
+  private _title: string | null = null;
+  private _titleChanged = new Signal<AIChatModel, string | null>(this);
 }
 
 namespace Private {

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -151,6 +151,9 @@ export class AIChatModel extends AbstractChatModel {
   }
   set title(value: string | null) {
     this._title = value;
+    if (this.autosave) {
+      this._autosaveDebouncer.invoke();
+    }
     this._titleChanged.emit(this._title);
   }
 

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -32,7 +32,7 @@ import { Debouncer } from '@lumino/polling';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
-import type { UserContent, ImagePart, FilePart } from 'ai';
+import type { UserContent, ImagePart, FilePart, ModelMessage } from 'ai';
 
 import { AI_AVATAR } from './icons';
 
@@ -441,6 +441,31 @@ export class AIChatModel extends AbstractChatModel {
     this.title = content.metadata?.title ?? null;
     return true;
   };
+
+  /**
+   * Request a title to this chat, regarding the message history.
+   */
+  async requestTitle(): Promise<string> {
+    const history = this.messages
+      .filter(msg => msg.body !== '')
+      .map(
+        msg =>
+          `${msg.sender.username === 'ai-assistant' ? 'assistant' : 'user'}: ${msg.body}`
+      )
+      .join('\n');
+    const messages: ModelMessage[] = [
+      {
+        role: 'system',
+        content:
+          'Generate a short title (max 10 words without formatting) for the following conversation. The title should reflect the first or the most representative expectation from the user.'
+      },
+      {
+        role: 'user',
+        content: history
+      }
+    ];
+    return this.agentManager.textResponse(messages);
+  }
 
   /**
    * Serialize the model for backup

--- a/src/index.ts
+++ b/src/index.ts
@@ -535,6 +535,18 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
         tracker.save(widget);
       }
 
+      function updateToolbarTitleOverlay() {
+        const titleNode = chatPanel.current?.toolbar.node
+          .getElementsByClassName('jp-chat-sidepanel-widget-title')
+          .item(0);
+        if (titleNode) {
+          titleNode.setAttribute('title', model.title ?? model.name);
+        }
+      }
+
+      model.titleChanged.connect(updateToolbarTitleOverlay);
+      updateToolbarTitleOverlay();
+
       // Update the tracker if the model name changed.
       model.nameChanged.connect(saveTracker);
 
@@ -590,6 +602,7 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
       });
 
       widget.disposed.connect(() => {
+        model.titleChanged.disconnect(updateToolbarTitleOverlay);
         model.nameChanged.disconnect(saveTracker);
         model.agentManager.activeProviderChanged.disconnect(saveTracker);
         model.writersChanged?.disconnect(writersChanged);
@@ -891,7 +904,8 @@ function registerCommands(
           activeProvider: previousModel.agentManager.activeProvider,
           tokenUsage: previousModel.agentManager.tokenUsage,
           messages: previousModel.messages,
-          autosave: previousModel.autosave
+          autosave: previousModel.autosave,
+          title: previousModel.title
         });
 
         // Wait (with timeout) for the tracker to have updated the previous widget.

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -4,7 +4,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { Token } from '@lumino/coreutils';
 import type { IDisposable } from '@lumino/disposable';
 import { ISignal } from '@lumino/signaling';
-import type { Tool, LanguageModel, UserContent } from 'ai';
+import type { Tool, LanguageModel, UserContent, ModelMessage } from 'ai';
 import { ISecretsManager } from 'jupyter-secrets-manager';
 
 import type { IModelOptions } from './providers/models';
@@ -612,6 +612,11 @@ export interface IAgentManager {
    * @param message The user message to respond to (may include processed attachment content)
    */
   generateResponse(message: UserContent): Promise<void>;
+  /**
+   * Create a transient language model to request a text response, which won't be added to history.
+   * @param messages - the messages sequence to send to the model.
+   */
+  textResponse(messages: ModelMessage[]): Promise<string>;
   /**
    * Initializes the AI agent with current settings and tools.
    * Sets up the agent with model configuration, tools, and MCP tools.

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -700,6 +700,10 @@ export interface ICreateChatOptions {
    * Whether the chat is autosaved or not.
    */
   autosave?: boolean;
+  /**
+   * An optional title to the chat.
+   */
+  title?: string | null;
 }
 /**
  * Token for the chat model handler.

--- a/src/widgets/main-area-chat.ts
+++ b/src/widgets/main-area-chat.ts
@@ -24,7 +24,8 @@ export namespace MainAreaChat {
 export class MainAreaChat extends MainAreaWidget<ChatWidget> {
   constructor(options: MainAreaChat.IOptions) {
     super(options);
-    this.title.label = this.content.model.name;
+    this.title.label = this.model.name;
+    this.title.caption = this.model.title ?? this.model.name;
 
     const { trans } = options;
 
@@ -69,6 +70,8 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
     });
 
     this.model.writersChanged.connect(this._writersChanged);
+
+    this.model.titleChanged.connect(this._titleChanged);
   }
 
   dispose(): void {
@@ -76,6 +79,7 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
     // Dispose of the approval buttons widget when the chat is disposed.
     this._outputAreaCompat.dispose();
     this.model.writersChanged.disconnect(this._writersChanged);
+    this.model.titleChanged.disconnect(this._titleChanged);
   }
 
   /**
@@ -105,6 +109,10 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
       this.content.inputToolbarRegistry?.hide('stop');
       this.content.inputToolbarRegistry?.show('send');
     }
+  };
+
+  private _titleChanged = () => {
+    this.title.caption = this.model.title ?? this.model.name;
   };
 
   private _outputAreaCompat: RenderedMessageOutputAreaCompat;


### PR DESCRIPTION
This PR add an optional title to the chat model.
When set, this title appears as an overlay on the chat name (tab for main area widget or toolbar for side panel widget). It is also saved in the backup file, and restored.

It also adds methods to generate a title:
- `textResponse` in agent, that creates a transient model and request a text from a sequence of messages.
- `requestTitle` in chat model, that create a simple prompt from messages to request a title to the chat, using the `textResponse` method.

It can be tested from the console (needs a chat with content to be relevant):

```js
model = jupyterapp.pluginRegistry._plugins.get('@jupyterlite/ai:plugin').service.currentWidget.model;
model.title = await model.requestTitle()
```
It will generate a title related to the chat history, and set it as title of the chat model.