### PR TITLE
Use grouped tool calls component

### DIFF
--- a/demo/uv.lock
+++ b/demo/uv.lock
@@ -743,11 +743,11 @@ wheels = [
 
 [[package]]
 name = "jupyter-chat-components"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/37/4db09a22ce6378e4c70a73a8ff42c6eec3ece0fb822791fde24c0437ab6d/jupyter_chat_components-0.4.0.tar.gz", hash = "sha256:faeade7b51ba4cddf73d7dadce6567171102a1e6f4c43d066f124a657363c395", size = 325776, upload-time = "2026-04-09T11:50:24.359Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/76/ae36d78570a0a8d9eed6e09c81af9ef022c9d1bf4ae43eaaeb6b4b9f7328/jupyter_chat_components-0.4.1.tar.gz", hash = "sha256:c7e8726a96f2610358c59b140189e15559e199dbd1d69dc769883a79a5649f08", size = 327493, upload-time = "2026-04-26T20:25:10.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b4/b32866340edcf6edfa5ddcb6aac8c22b62d3eccebb68d406918657cf6c47/jupyter_chat_components-0.4.0-py3-none-any.whl", hash = "sha256:1b99a04aaf305c0999ed863d9a24a786f6b4743748c2c274f39b45c5ec5b0887", size = 31906, upload-time = "2026-04-09T11:50:22.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/00/7e4103bae103495456db1029028bfaeb3ac6e506e34010342b15584b1760/jupyter_chat_components-0.4.1-py3-none-any.whl", hash = "sha256:eea79dda0c0a65b10e493f6d1ada36ddd6da5481afecc804202ea17d8e5358b2", size = 32084, upload-time = "2026-04-26T20:25:09.044Z" },
 ]
 
 [[package]]

--- a/demo/uv.lock
+++ b/demo/uv.lock
@@ -743,11 +743,11 @@ wheels = [
 
 [[package]]
 name = "jupyter-chat-components"
-version = "0.2.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/e7/b8b85349a84a4502df7db865000f15911796b22a7013a93dc01265b25cd7/jupyter_chat_components-0.2.0.tar.gz", hash = "sha256:0e8ad59a8baf4fa4ef8f1479f39bdde8bff208317c63c0a892806392f12e88eb", size = 313589, upload-time = "2026-03-16T12:36:40.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/37/4db09a22ce6378e4c70a73a8ff42c6eec3ece0fb822791fde24c0437ab6d/jupyter_chat_components-0.4.0.tar.gz", hash = "sha256:faeade7b51ba4cddf73d7dadce6567171102a1e6f4c43d066f124a657363c395", size = 325776, upload-time = "2026-04-09T11:50:24.359Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/70/118a38f898d39f6fb9beb5266a72eef21f7173a17e82f8157e11c5a47687/jupyter_chat_components-0.2.0-py3-none-any.whl", hash = "sha256:de95a07a22fe3b5a229af8806f8c26eae3816c660313d376f45bab9838e475ab", size = 28370, upload-time = "2026-03-16T12:36:38.58Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b4/b32866340edcf6edfa5ddcb6aac8c22b62d3eccebb68d406918657cf6c47/jupyter_chat_components-0.4.0-py3-none-any.whl", hash = "sha256:1b99a04aaf305c0999ed863d9a24a786f6b4743748c2c274f39b45c5ec5b0887", size = 31906, upload-time = "2026-04-09T11:50:22.597Z" },
 ]
 
 [[package]]
@@ -1000,7 +1000,7 @@ dependencies = [
 requires-dist = [
     { name = "fastmcp", marker = "extra == 'test'", specifier = ">=3.2.3,<4" },
     { name = "jupyter-book", marker = "extra == 'docs'" },
-    { name = "jupyter-chat-components", specifier = ">=0.2.0,<0.3" },
+    { name = "jupyter-chat-components", specifier = ">=0.4.0,<0.5" },
     { name = "jupyter-secrets-manager", specifier = ">=0.5,<0.6" },
     { name = "jupyterlab", marker = "extra == 'jupyter'", specifier = ">=4.4.0" },
     { name = "jupyterlab-ai-commands", specifier = ">=0.3.1,<0.4" },

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "@mui/icons-material": "^7",
         "@mui/material": "^7",
         "ai": "^6.0.116",
-        "jupyter-chat-components": "^0.2.0",
+        "jupyter-chat-components": "^0.4.0",
         "jupyter-secrets-manager": "^0.5.0",
         "yaml": "^2.8.1",
         "zod": "^4.3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "jupyter-chat-components >=0.2.0,<0.3",
+    "jupyter-chat-components >=0.4.0,<0.5",
     "jupyter-secrets-manager >=0.5,<0.6",
     "jupyterlab-ai-commands >=0.3.1,<0.4",
 ]

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -494,11 +494,11 @@ export class AgentManager implements IAgentManager {
     // Stop any ongoing streaming and reject awaiting approvals
     this.stopStreaming();
 
-    for (const [approvalId, pending] of this._pendingApprovals) {
+    for (const [toolCallId, pending] of this._pendingApprovals) {
       pending.resolve(false, 'Chat history changed');
       this._agentEvent.emit({
         type: 'tool_approval_resolved',
-        data: { approvalId, approved: false }
+        data: { toolCallId, approved: false }
       });
     }
     this._pendingApprovals.clear();
@@ -522,11 +522,11 @@ export class AgentManager implements IAgentManager {
     this._controller?.abort();
 
     // Reject any pending approvals
-    for (const [approvalId, pending] of this._pendingApprovals) {
+    for (const [toolCallId, pending] of this._pendingApprovals) {
       pending.resolve(false, reason ?? 'Stream ended by user');
       this._agentEvent.emit({
         type: 'tool_approval_resolved',
-        data: { approvalId, approved: false }
+        data: { toolCallId, approved: false }
       });
     }
     this._pendingApprovals.clear();
@@ -534,34 +534,34 @@ export class AgentManager implements IAgentManager {
 
   /**
    * Approves a pending tool call.
-   * @param approvalId The approval ID to approve
+   * @param toolCallId The tool call ID to approve
    * @param reason Optional reason for approval
    */
-  approveToolCall(approvalId: string, reason?: string): void {
-    const pending = this._pendingApprovals.get(approvalId);
+  approveToolCall(toolCallId: string, reason?: string): void {
+    const pending = this._pendingApprovals.get(toolCallId);
     if (pending) {
       pending.resolve(true, reason);
-      this._pendingApprovals.delete(approvalId);
+      this._pendingApprovals.delete(toolCallId);
       this._agentEvent.emit({
         type: 'tool_approval_resolved',
-        data: { approvalId, approved: true }
+        data: { toolCallId, approved: true }
       });
     }
   }
 
   /**
    * Rejects a pending tool call.
-   * @param approvalId The approval ID to reject
+   * @param toolCallId The tool call ID to reject
    * @param reason Optional reason for rejection
    */
-  rejectToolCall(approvalId: string, reason?: string): void {
-    const pending = this._pendingApprovals.get(approvalId);
+  rejectToolCall(toolCallId: string, reason?: string): void {
+    const pending = this._pendingApprovals.get(toolCallId);
     if (pending) {
       pending.resolve(false, reason);
-      this._pendingApprovals.delete(approvalId);
+      this._pendingApprovals.delete(toolCallId);
       this._agentEvent.emit({
         type: 'tool_approval_resolved',
-        data: { approvalId, approved: false }
+        data: { toolCallId, approved: false }
       });
     }
   }
@@ -1034,14 +1034,13 @@ ${richOutputWorkflowInstruction}`;
     this._agentEvent.emit({
       type: 'tool_approval_request',
       data: {
-        approvalId,
         toolCallId: toolCall.toolCallId,
         toolName: toolCall.toolName,
         args: toolCall.input
       }
     });
 
-    const approved = await this._waitForApproval(approvalId);
+    const approved = await this._waitForApproval(toolCall.toolCallId);
 
     result.approvalProcessed = true;
     result.approvalResponse = {
@@ -1058,12 +1057,12 @@ ${richOutputWorkflowInstruction}`;
 
   /**
    * Waits for user approval of a tool call.
-   * @param approvalId The approval ID to wait for
+   * @param toolCallId The tool call ID to wait for approval
    * @returns Promise that resolves to true if approved, false if rejected
    */
-  private _waitForApproval(approvalId: string): Promise<boolean> {
+  private _waitForApproval(toolCallId: string): Promise<boolean> {
     return new Promise(resolve => {
-      this._pendingApprovals.set(approvalId, {
+      this._pendingApprovals.set(toolCallId, {
         resolve: (approved: boolean) => {
           resolve(approved);
         }

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -861,8 +861,8 @@ export class AIChatModel extends AbstractChatModel {
                 status === 'awaiting_approval' ? 'pending' : 'resolved',
               ...(status === 'awaiting_approval' && {
                 permissionOptions: [
-                  { optionId: 'approve', name: 'Approve', kind: 'approve' },
-                  { optionId: 'reject', name: 'Reject', kind: 'reject' }
+                  { optionId: 'approve', name: 'Approve', kind: 'allow_once' },
+                  { optionId: 'reject', name: 'Reject', kind: 'reject_once' }
                 ]
               })
             }

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -702,7 +702,7 @@ export class AIChatModel extends AbstractChatModel {
           toolCalls: [
             {
               toolCallId: context.toolCallId,
-              title: context.summary || context.toolName,
+              title: `${context.toolName}${context.summary ? ' : ' + context.summary : ''}`,
               kind: context.toolName,
               status: 'in_progress',
               rawInput: context.input
@@ -851,7 +851,7 @@ export class AIChatModel extends AbstractChatModel {
           toolCalls: [
             {
               toolCallId: context.toolCallId,
-              title: context.summary || context.toolName,
+              title: `${context.toolName}${context.summary ? ' : ' + context.summary : ''}`,
               kind: context.toolName,
               status: context.status,
               rawInput: context.input,

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -700,13 +700,18 @@ export class AIChatModel extends AbstractChatModel {
       body: '',
       mime_model: {
         data: {
-          'application/vnd.jupyter.chat.components': 'tool-call'
+          'application/vnd.jupyter.chat.components': 'grouped-tool-calls'
         },
         metadata: {
-          toolName: context.toolName,
-          input: context.input,
-          status: context.status,
-          summary: context.summary
+          toolCalls: [
+            {
+              toolCallId: context.toolCallId,
+              title: context.summary || context.toolName,
+              kind: context.toolName,
+              status: 'in_progress',
+              rawInput: context.input
+            }
+          ]
         }
       },
       sender: this._getAIUser(),
@@ -824,6 +829,15 @@ export class AIChatModel extends AbstractChatModel {
   }
 
   /**
+   * Gets the approval ID for a given tool call ID.
+   * @param toolCallId The tool call ID
+   * @returns The approval ID or null if not found
+   */
+  getApprovalIdForToolCall(toolCallId: string): string | null {
+    return this._toolContexts.get(toolCallId)?.approvalId || null;
+  }
+
+  /**
    * Updates a tool call's UI with new status and optional output.
    */
   private _updateToolCallUI(
@@ -847,16 +861,29 @@ export class AIChatModel extends AbstractChatModel {
     existingMessage.update({
       mime_model: {
         data: {
-          'application/vnd.jupyter.chat.components': 'tool-call'
+          'application/vnd.jupyter.chat.components': 'grouped-tool-calls'
         },
         metadata: {
-          toolName: context.toolName,
-          input: context.input,
-          status: context.status,
-          summary: context.summary,
-          output,
-          targetId: this.name,
-          approvalId: context.approvalId
+          toolCalls: [
+            {
+              toolCallId: context.toolCallId,
+              title: context.summary || context.toolName,
+              kind: context.toolName,
+              status: context.status,
+              rawInput: context.input,
+              rawOutput: output,
+              sessionId: this.name,
+              permissionStatus:
+                status === 'awaiting_approval' ? 'pending' : 'resolved',
+              ...(context.approvalId &&
+                status === 'awaiting_approval' && {
+                  permissionOptions: [
+                    { optionId: 'approve', name: 'Approve', kind: 'approve' },
+                    { optionId: 'reject', name: 'Reject', kind: 'reject' }
+                  ]
+                })
+            }
+          ]
         }
       }
     });

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -67,10 +67,6 @@ interface IToolExecutionContext {
    */
   input: string;
   /**
-   * Optional approval ID if awaiting approval.
-   */
-  approvalId?: string;
-  /**
    * Current status.
    */
   status: ToolStatus;
@@ -802,7 +798,6 @@ export class AIChatModel extends AbstractChatModel {
     if (!context) {
       return;
     }
-    context.approvalId = event.data.approvalId;
     context.input = JSON.stringify(event.data.args, null, 2);
     this._updateToolCallUI(event.data.toolCallId, 'awaiting_approval');
   }
@@ -813,28 +808,17 @@ export class AIChatModel extends AbstractChatModel {
   private _handleToolApprovalResolved(
     event: IAgentManager.IAgentEvent<'tool_approval_resolved'>
   ): void {
-    const context = Array.from(this._toolContexts.values()).find(
-      ctx => ctx.approvalId === event.data.approvalId
-    );
+    const context = this._toolContexts.get(event.data.toolCallId);
     if (!context) {
       return;
     }
 
     const status = event.data.approved ? 'approved' : 'rejected';
-    this._updateToolCallUI(context.toolCallId, status);
+    this._updateToolCallUI(event.data.toolCallId, status);
 
     if (!event.data.approved) {
       this._toolContexts.delete(context.toolCallId);
     }
-  }
-
-  /**
-   * Gets the approval ID for a given tool call ID.
-   * @param toolCallId The tool call ID
-   * @returns The approval ID or null if not found
-   */
-  getApprovalIdForToolCall(toolCallId: string): string | null {
-    return this._toolContexts.get(toolCallId)?.approvalId || null;
   }
 
   /**
@@ -875,13 +859,12 @@ export class AIChatModel extends AbstractChatModel {
               sessionId: this.name,
               permissionStatus:
                 status === 'awaiting_approval' ? 'pending' : 'resolved',
-              ...(context.approvalId &&
-                status === 'awaiting_approval' && {
-                  permissionOptions: [
-                    { optionId: 'approve', name: 'Approve', kind: 'approve' },
-                    { optionId: 'reject', name: 'Reject', kind: 'reject' }
-                  ]
-                })
+              ...(status === 'awaiting_approval' && {
+                permissionOptions: [
+                  { optionId: 'approve', name: 'Approve', kind: 'approve' },
+                  { optionId: 'reject', name: 'Reject', kind: 'reject' }
+                ]
+              })
             }
           ]
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -654,17 +654,10 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
         return;
       }
 
-      // Find the approval ID for this tool call ID
-      const approvalId = model.getApprovalIdForToolCall(toolCallId);
-      if (!approvalId) {
-        console.error(`No approval ID found for tool call ${toolCallId}`);
-        return;
-      }
-
       const isApproved = optionId === 'approve';
       isApproved
-        ? model.agentManager.approveToolCall(approvalId)
-        : model.agentManager.rejectToolCall(approvalId);
+        ? model.agentManager.approveToolCall(toolCallId)
+        : model.agentManager.rejectToolCall(toolCallId);
     }
 
     if (chatComponentsFactory) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -641,24 +641,35 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
     );
 
     /**
-     * The callback to approve or reject a tool.
+     * The callback for grouped tool calls permission decisions.
      */
-    function toolCallApproval(
-      targetId: string,
-      approvalId: string,
-      isApproved: boolean
+    function toolCallPermissionDecision(
+      sessionId: string,
+      toolCallId: string,
+      optionId: string
     ) {
-      const model = tracker.find(chat => chat.model.name === targetId)?.model;
+      const model = tracker.find(chat => chat.model.name === sessionId)
+        ?.model as AIChatModel;
       if (!model) {
         return;
       }
+
+      // Find the approval ID for this tool call ID
+      const approvalId = model.getApprovalIdForToolCall(toolCallId);
+      if (!approvalId) {
+        console.error(`No approval ID found for tool call ${toolCallId}`);
+        return;
+      }
+
+      const isApproved = optionId === 'approve';
       isApproved
-        ? (model as AIChatModel).agentManager.approveToolCall(approvalId)
-        : (model as AIChatModel).agentManager.rejectToolCall(approvalId);
+        ? model.agentManager.approveToolCall(approvalId)
+        : model.agentManager.rejectToolCall(approvalId);
     }
 
     if (chatComponentsFactory) {
-      chatComponentsFactory.toolCallApproval = toolCallApproval;
+      chatComponentsFactory.toolCallPermissionDecision =
+        toolCallPermissionDecision;
     }
 
     return tracker;

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -513,13 +513,12 @@ export namespace IAgentManager {
       isError: boolean;
     };
     tool_approval_request: {
-      approvalId: string;
       toolCallId: string;
       toolName: string;
       args: unknown;
     };
     tool_approval_resolved: {
-      approvalId: string;
+      toolCallId: string;
       approved: boolean;
     };
     error: {
@@ -596,16 +595,16 @@ export interface IAgentManager {
   stopStreaming(): void;
   /**
    * Approves a pending tool call.
-   * @param approvalId The approval ID to approve
+   * @param toolCallId The tool call ID to approve
    * @param reason Optional reason for approval
    */
-  approveToolCall(approvalId: string, reason?: string): void;
+  approveToolCall(toolCallId: string, reason?: string): void;
   /**
    * Rejects a pending tool call.
-   * @param approvalId The approval ID to reject
+   * @param toolCallId The tool call ID to reject
    * @param reason Optional reason for rejection
    */
-  rejectToolCall(approvalId: string, reason?: string): void;
+  rejectToolCall(toolCallId: string, reason?: string): void;
   /**
    * Generates AI response to user message using the agent.
    * Handles the complete execution cycle including tool calls.

--- a/ui-tests/tests/browser-fetch-tool.spec.ts
+++ b/ui-tests/tests/browser-fetch-tool.spec.ts
@@ -61,15 +61,19 @@ test.describe('#browserFetchTool', () => {
       timeout: EXPECT_TIMEOUT
     });
 
+    // Open tool call details
     await browserFetchCall.click();
 
-    await expect(browserFetchCall).toContainText('"success": true', {
+    const toolCallDetails = browserFetchCall.locator(
+      '> .jp-ai-tool-call-item-detail'
+    );
+    await expect(toolCallDetails).toContainText('"success": true', {
       timeout: EXPECT_TIMEOUT
     });
-    await expect(browserFetchCall).toContainText('"status": 200', {
+    await expect(toolCallDetails).toContainText('"status": 200', {
       timeout: EXPECT_TIMEOUT
     });
-    await expect(browserFetchCall).toContainText('mcp-server', {
+    await expect(toolCallDetails).toContainText('mcp-server', {
       timeout: EXPECT_TIMEOUT
     });
   });

--- a/ui-tests/tests/browser-fetch-tool.spec.ts
+++ b/ui-tests/tests/browser-fetch-tool.spec.ts
@@ -52,7 +52,7 @@ test.describe('#browserFetchTool', () => {
     ).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     const browserFetchCall = panel
-      .locator('.jp-ai-tool-call')
+      .locator('.jp-ai-tool-call-item')
       .filter({ hasText: 'browser_fetch' })
       .first();
 

--- a/ui-tests/tests/commands-tool.spec.ts
+++ b/ui-tests/tests/commands-tool.spec.ts
@@ -55,7 +55,7 @@ test.describe('#commandsTool', () => {
     await expect(stopButton).toHaveCount(0, { timeout: EXPECT_TIMEOUT });
 
     // Wait for tool call to appear
-    const toolCall = panel.locator('.jp-ai-tool-call-item');
+    const toolCall = panel.locator('.jp-ai-tool-call-item > summary');
     await expect(toolCall).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     await expect(toolCall).toContainText('discover_commands', {
@@ -69,7 +69,8 @@ test.describe('#commandsTool', () => {
     await toolCall.click();
 
     // Get the tool call result to check the command count
-    const toolResultText = await toolCall.textContent();
+    const toolCallDetails = panel.locator('.jp-ai-tool-call-item-detail');
+    const toolResultText = await toolCallDetails.textContent();
 
     // Parse the commandCount from the JSON response
     const countMatch = toolResultText?.match(/"commandCount":\s*(\d+)/);
@@ -106,7 +107,7 @@ test.describe('#commandsTool', () => {
     const stopButton = panel.getByTitle('Stop streaming');
     await expect(stopButton).toHaveCount(0, { timeout: EXPECT_TIMEOUT });
 
-    const toolCall = panel.locator('.jp-ai-tool-call-item');
+    const toolCall = panel.locator('.jp-ai-tool-call-item > summary');
     await expect(toolCall).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     await expect(toolCall).toContainText('discover_commands', {
@@ -116,9 +117,12 @@ test.describe('#commandsTool', () => {
       timeout: EXPECT_TIMEOUT
     });
 
+    // Click to expand the tool call
     await toolCall.click();
 
-    const toolResultText = await toolCall.textContent();
+    // Get the tool call result to check the command count
+    const toolCallDetails = panel.locator('.jp-ai-tool-call-item-detail');
+    const toolResultText = await toolCallDetails.textContent();
 
     const countMatch = toolResultText?.match(/"commandCount":\s*(\d+)/);
     expect(countMatch).toBeTruthy();
@@ -158,7 +162,7 @@ test.describe('#commandsTool', () => {
     await expect(stopButton).toHaveCount(0, { timeout: EXPECT_TIMEOUT });
 
     // Wait for tool call to appear
-    const toolCall = panel.locator('.jp-ai-tool-call-item');
+    const toolCall = panel.locator('.jp-ai-tool-call-item > summary');
     await expect(toolCall).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     // Verify the tool was called
@@ -175,7 +179,8 @@ test.describe('#commandsTool', () => {
     await toolCall.click();
 
     // Get the tool call result to check the command count
-    const toolResultText = await toolCall.textContent();
+    const toolCallDetails = panel.locator('.jp-ai-tool-call-item-detail');
+    const toolResultText = await toolCallDetails.textContent();
 
     // Parse the commandCount from the JSON response
     const countMatch = toolResultText?.match(/"commandCount":\s*(\d+)/);
@@ -215,7 +220,7 @@ test.describe('#commandsTool', () => {
     await expect(stopButton).toHaveCount(0, { timeout: EXPECT_TIMEOUT });
 
     // Wait for tool call to appear
-    const toolCall = panel.locator('.jp-ai-tool-call-item');
+    const toolCall = panel.locator('.jp-ai-tool-call-item > summary');
     await expect(toolCall).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     // Verify the tool was called and the command name is displayed in the summary

--- a/ui-tests/tests/commands-tool.spec.ts
+++ b/ui-tests/tests/commands-tool.spec.ts
@@ -55,7 +55,7 @@ test.describe('#commandsTool', () => {
     await expect(stopButton).toHaveCount(0, { timeout: EXPECT_TIMEOUT });
 
     // Wait for tool call to appear
-    const toolCall = panel.locator('.jp-ai-tool-call');
+    const toolCall = panel.locator('.jp-ai-tool-call-item');
     await expect(toolCall).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     await expect(toolCall).toContainText('discover_commands', {
@@ -106,7 +106,7 @@ test.describe('#commandsTool', () => {
     const stopButton = panel.getByTitle('Stop streaming');
     await expect(stopButton).toHaveCount(0, { timeout: EXPECT_TIMEOUT });
 
-    const toolCall = panel.locator('.jp-ai-tool-call');
+    const toolCall = panel.locator('.jp-ai-tool-call-item');
     await expect(toolCall).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     await expect(toolCall).toContainText('discover_commands', {
@@ -158,7 +158,7 @@ test.describe('#commandsTool', () => {
     await expect(stopButton).toHaveCount(0, { timeout: EXPECT_TIMEOUT });
 
     // Wait for tool call to appear
-    const toolCall = panel.locator('.jp-ai-tool-call');
+    const toolCall = panel.locator('.jp-ai-tool-call-item');
     await expect(toolCall).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     // Verify the tool was called
@@ -215,7 +215,7 @@ test.describe('#commandsTool', () => {
     await expect(stopButton).toHaveCount(0, { timeout: EXPECT_TIMEOUT });
 
     // Wait for tool call to appear
-    const toolCall = panel.locator('.jp-ai-tool-call');
+    const toolCall = panel.locator('.jp-ai-tool-call-item');
     await expect(toolCall).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     // Verify the tool was called and the command name is displayed in the summary

--- a/ui-tests/tests/mcp-integration.spec.ts
+++ b/ui-tests/tests/mcp-integration.spec.ts
@@ -56,7 +56,7 @@ test.describe('#mcpIntegration', () => {
     ).toHaveCount(1, { timeout: 60000 });
 
     // Wait for tool call to appear
-    const toolCall = panel.locator('.jp-ai-tool-call');
+    const toolCall = panel.locator('.jp-ai-tool-call-item');
     await expect(toolCall).toHaveCount(1, { timeout: 30000 });
 
     await expect(

--- a/ui-tests/tests/mime-bundles.spec.ts
+++ b/ui-tests/tests/mime-bundles.spec.ts
@@ -106,7 +106,7 @@ test.describe('#mimeBundles', () => {
     ).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     const executeToolCall = panel
-      .locator('.jp-ai-tool-call')
+      .locator('.jp-ai-tool-call-item')
       .filter({ hasText: TEST_MIME_BUNDLE_COMMAND_ID });
     await expect(executeToolCall).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
     await expect(executeToolCall).toContainText('execute_command', {
@@ -161,7 +161,7 @@ test.describe('#mimeBundles', () => {
     await sendButton.click();
 
     const executeToolCalls = panel
-      .locator('.jp-ai-tool-call')
+      .locator('.jp-ai-tool-call-item')
       .filter({ hasText: TEST_MIME_BUNDLE_COMMAND_ID });
     await expect(executeToolCalls).toHaveCount(2, { timeout: EXPECT_TIMEOUT });
     await expect(renderedJson).toHaveCount(2, { timeout: EXPECT_TIMEOUT });

--- a/ui-tests/tests/mime-bundles.spec.ts
+++ b/ui-tests/tests/mime-bundles.spec.ts
@@ -112,13 +112,19 @@ test.describe('#mimeBundles', () => {
     await expect(executeToolCall).toContainText('execute_command', {
       timeout: EXPECT_TIMEOUT
     });
-    await expect(executeToolCall).toContainText(
+
+    // Click to expand the tool call
+    await executeToolCall.click();
+    const toolCallDetails = executeToolCall.locator(
+      '> .jp-ai-tool-call-item-detail'
+    );
+    await expect(toolCallDetails).toContainText(
       `"commandId": "${TEST_MIME_BUNDLE_COMMAND_ID}"`,
       {
         timeout: EXPECT_TIMEOUT
       }
     );
-    await expect(executeToolCall).not.toContainText('"args": "', {
+    await expect(toolCallDetails).not.toContainText('"args": "', {
       timeout: EXPECT_TIMEOUT
     });
 

--- a/ui-tests/tests/skills.spec.ts
+++ b/ui-tests/tests/skills.spec.ts
@@ -65,7 +65,7 @@ test.describe('#skills', () => {
     ).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     const messages = panel.locator('.jp-chat-message');
-    const toolCalls = panel.locator('.jp-ai-tool-call');
+    const toolCalls = panel.locator('.jp-ai-tool-call-item');
     const loadCall = toolCalls.filter({ hasText: 'load_skill' });
     const skillCall = toolCalls.filter({ hasText: /agent-helper/ });
 

--- a/ui-tests/tests/skills.spec.ts
+++ b/ui-tests/tests/skills.spec.ts
@@ -65,7 +65,7 @@ test.describe('#skills', () => {
     ).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     const messages = panel.locator('.jp-chat-message');
-    const toolCalls = panel.locator('.jp-ai-tool-call-item');
+    const toolCalls = panel.locator('.jp-ai-tool-call-item > summary');
     const loadCall = toolCalls.filter({ hasText: 'load_skill' });
     const skillCall = toolCalls.filter({ hasText: /agent-helper/ });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3075,7 +3075,7 @@ __metadata:
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^5.0.0
-    jupyter-chat-components: ^0.2.0
+    jupyter-chat-components: ^0.4.0
     jupyter-secrets-manager: ^0.5.0
     npm-run-all2: ^7.0.1
     prettier: ^3.0.0
@@ -7498,9 +7498,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jupyter-chat-components@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "jupyter-chat-components@npm:0.2.0"
+"jupyter-chat-components@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "jupyter-chat-components@npm:0.4.0"
   dependencies:
     "@jupyterlab/application": ^4.5.0
     "@jupyterlab/coreutils": ^6.5.4
@@ -7510,7 +7510,7 @@ __metadata:
     "@lumino/coreutils": ^2.2.2
     "@lumino/widgets": ^2.1.0
     diff: ^8.0.0
-  checksum: a79e1ec2a85551a042022721983660b7bb6a0bf6a94c32e67a9c6fcd150610fc96ba953bcb98ce986f61843cfadbb7958c33df6bdf1bdd15bbc285762ef38191
+  checksum: 67fb8539bff96a918f43ab58fb6ca01d3b51f4a423acc8bf0012e754737b522c63f595dfff888fe911ebcb10a06f844d7c6e86703deaea5c40d3b95f5704c551
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. The first intention of this PR is to replace the [tool call](https://github.com/brichet/jupyter-chat-components/blob/8c60e70b83fe49622fe85db99f5ea0109f950f52/src/components/tool-call.tsx#L122) component by the [grouped tool calls](https://github.com/brichet/jupyter-chat-components/blob/8c60e70b83fe49622fe85db99f5ea0109f950f52/src/components/grouped-tool-calls.tsx#L681) component.

    There is probably no need to maintain both tool call components in the long run, so we could use the same as `jupyter-ai`.

    [output.webm](https://github.com/user-attachments/assets/24f10eb0-9e0f-4670-a956-fe1fa6c64809)


2. It also removes the `approvalID` that is shared during the awaiting approval process.

    In the current implementation, there can be only one approval ID per tool call ID, so we don't really need it outside of the `_handleApprovalRequest` of the agent.
    This change can easily be reverted if not expected (could we have several approval ID for one tool call ? ) 