### PR TITLE
Export an interface for the ai chat model

### DIFF
--- a/src/chat-model-handler.ts
+++ b/src/chat-model-handler.ts
@@ -6,6 +6,7 @@ import { Contents } from '@jupyterlab/services';
 import { AIChatModel } from './chat-model';
 import type {
   IAgentManagerFactory,
+  IAIChatModel,
   IAISettingsModel,
   IChatModelHandler,
   ICreateChatOptions,
@@ -28,7 +29,7 @@ export class ChatModelHandler implements IChatModelHandler {
     this._contentsManager = options.contentsManager;
   }
 
-  createModel(options: ICreateChatOptions): AIChatModel {
+  createModel(options: ICreateChatOptions): IAIChatModel {
     const { name, activeProvider, tokenUsage, messages, autosave, title } =
       options;
 

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -38,6 +38,7 @@ import { AI_AVATAR } from './icons';
 
 import type {
   IAgentManager,
+  IAIChatModel,
   IAISettingsModel,
   IProviderRegistry,
   ITokenUsage
@@ -98,7 +99,7 @@ interface IToolExecutionContext {
  * AI Chat Model implementation that provides chat functionality tool integration,
  * and MCP server support.
  */
-export class AIChatModel extends AbstractChatModel {
+export class AIChatModel extends AbstractChatModel implements IAIChatModel {
   /**
    * Constructs a new AIChatModel instance.
    * @param options Configuration options for the chat model
@@ -154,7 +155,7 @@ export class AIChatModel extends AbstractChatModel {
   /**
    * A signal emitting when the chat name has changed.
    */
-  get nameChanged(): ISignal<AIChatModel, string> {
+  get nameChanged(): ISignal<IAIChatModel, string> {
     return this._nameChanged;
   }
 
@@ -175,7 +176,7 @@ export class AIChatModel extends AbstractChatModel {
   /**
    * A signal emitting when the chat title has changed.
    */
-  get titleChanged(): ISignal<AIChatModel, string | null> {
+  get titleChanged(): ISignal<IAIChatModel, string | null> {
     return this._titleChanged;
   }
 
@@ -216,7 +217,7 @@ export class AIChatModel extends AbstractChatModel {
   /**
    * A signal emitting when the autosave flag changed.
    */
-  get autosaveChanged(): ISignal<AIChatModel, boolean> {
+  get autosaveChanged(): ISignal<IAIChatModel, boolean> {
     return this._autosaveChanged;
   }
 
@@ -235,7 +236,7 @@ export class AIChatModel extends AbstractChatModel {
   }
 
   /**
-   * Get the agent manager associated to the model.
+   * The agent manager used in the model.
    */
   get agentManager(): IAgentManager {
     return this._agentManager;
@@ -271,7 +272,7 @@ export class AIChatModel extends AbstractChatModel {
       stopStreaming: () => this.stopStreaming(),
       clearMessages: () => this.clearMessages(),
       agentManager: this._agentManager,
-      addSystemMessage: (body: string) => this.addSystemMessage(body)
+      addSystemMessage: (body: string) => this._addSystemMessage(body)
     };
   }
 
@@ -295,7 +296,7 @@ export class AIChatModel extends AbstractChatModel {
   /**
    * Adds a non-user message to the chat (used by chat commands).
    */
-  addSystemMessage(body: string): void {
+  private _addSystemMessage(body: string): void {
     const message: IMessageContent = {
       body,
       sender: this._getAIUser(),
@@ -1050,13 +1051,13 @@ export class AIChatModel extends AbstractChatModel {
   private _providerRegistry?: IProviderRegistry;
   private _currentModelKey: string | undefined;
   private _currentStreamingMessage: IMessage | null = null;
-  private _nameChanged = new Signal<AIChatModel, string>(this);
+  private _nameChanged = new Signal<IAIChatModel, string>(this);
   private _contentsManager?: Contents.IManager;
   private _autosave: boolean = false;
-  private _autosaveChanged = new Signal<AIChatModel, boolean>(this);
+  private _autosaveChanged = new Signal<IAIChatModel, boolean>(this);
   private _autosaveDebouncer: Debouncer;
   private _title: string | null = null;
-  private _titleChanged = new Signal<AIChatModel, string | null>(this);
+  private _titleChanged = new Signal<IAIChatModel, string | null>(this);
 }
 
 namespace Private {

--- a/src/components/save-button.tsx
+++ b/src/components/save-button.tsx
@@ -7,7 +7,7 @@ import {
 import type { TranslationBundle } from '@jupyterlab/translation';
 import React, { useEffect, useState } from 'react';
 
-import { AIChatModel } from '../chat-model';
+import { IAIChatModel } from '../tokens';
 
 const COMPONENT_CLASS = 'jp-ai-SaveButton';
 const AUTOSAVE_BUTTON_CLASS = 'jp-ai-AutoSaveButton';
@@ -19,7 +19,7 @@ export interface ISaveButtonProps {
   /**
    * The chat model, used to listen for message changes for auto-save.
    */
-  model: AIChatModel;
+  model: IAIChatModel;
   /**
    * The application language translator.
    */
@@ -40,7 +40,7 @@ export function SaveComponent(props: ISaveButtonProps): JSX.Element {
    * Effect that update the autosave state when it is updated on the model.
    */
   useEffect(() => {
-    const updateAutosave = (_: AIChatModel, value: boolean) => {
+    const updateAutosave = (_: IAIChatModel, value: boolean) => {
       setAutosave(value);
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,6 @@ import { ISecretsManager, SecretsManager } from 'jupyter-secrets-manager';
 
 import { AgentManagerFactory } from './agent';
 
-import { AIChatModel } from './chat-model';
-
 import { RenderedMessageOutputAreaCompat } from './rendered-message-outputarea';
 
 import { ClearCommandProvider } from './chat-commands/clear';
@@ -95,7 +93,8 @@ import {
   IProviderRegistry,
   IToolRegistry,
   ISkillRegistry,
-  SECRETS_NAMESPACE
+  SECRETS_NAMESPACE,
+  IAIChatModel
 } from './tokens';
 
 import {
@@ -526,7 +525,7 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
 
     let usageWidget: UsageWidget | null = null;
     chatPanel.chatOpened.connect((_, widget) => {
-      const model = widget.model as AIChatModel;
+      const model = widget.model as IAIChatModel;
 
       // Add the widget to the tracker.
       tracker.add(widget);
@@ -628,7 +627,7 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
         args: widget => ({
           name: widget.model.name,
           area: widget instanceof MainAreaChat ? 'main' : 'side',
-          provider: (widget.model as AIChatModel).agentManager.activeProvider
+          provider: (widget.model as IAIChatModel).agentManager.activeProvider
         }),
         name: widget => {
           const area = widget instanceof MainAreaChat ? 'main' : 'side';
@@ -670,7 +669,7 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
       optionId: string
     ) {
       const model = tracker.find(chat => chat.model.name === sessionId)
-        ?.model as AIChatModel;
+        ?.model as IAIChatModel;
       if (!model) {
         return;
       }
@@ -759,7 +758,7 @@ function registerCommands(
       }
     });
 
-    const openInMain = (model: AIChatModel): MainAreaChat => {
+    const openInMain = (model: IAIChatModel): MainAreaChat => {
       const inputToolbarRegistry = inputToolbarFactory.create();
       const content = new ChatWidget({
         model,
@@ -832,7 +831,7 @@ function registerCommands(
         return;
       }
       return tracker.find(widget => {
-        const model = widget.model as AIChatModel;
+        const model = widget.model as IAIChatModel;
         return (
           (!name || widget.model.name === name) &&
           (!provider || model.agentManager.activeProvider === provider)
@@ -1069,11 +1068,11 @@ function registerCommands(
           return false;
         }
         let previousWidget: ChatWidget | MainAreaChat | undefined;
-        let previousModel: AIChatModel | undefined;
+        let previousModel: IAIChatModel | undefined;
         tracker.forEach(widget => {
           if (widget.model.name === args.name) {
             previousWidget = widget;
-            previousModel = widget.model as AIChatModel;
+            previousModel = widget.model as IAIChatModel;
           }
         });
 
@@ -1167,15 +1166,15 @@ function registerCommands(
       caption: trans.__('Save the chat as local file'),
       icon: saveIcon,
       execute: async (args): Promise<boolean> => {
-        let model: AIChatModel | null = null;
+        let model: IAIChatModel | null = null;
         if (args.name) {
           tracker.forEach(widget => {
             if (widget.model.name === args.name) {
-              model = widget.model as AIChatModel;
+              model = widget.model as IAIChatModel;
             }
           });
         } else {
-          model = (tracker.currentWidget?.model as AIChatModel) ?? null;
+          model = (tracker.currentWidget?.model as IAIChatModel) ?? null;
         }
         if (model === null) {
           console.log('No chat to save');
@@ -1212,15 +1211,15 @@ function registerCommands(
           console.warn('The restoration is not possible');
           return false;
         }
-        let model: AIChatModel | null = null;
+        let model: IAIChatModel | null = null;
         if (args.name) {
           tracker.forEach(widget => {
             if (widget.model.name === args.name) {
-              model = widget.model as AIChatModel;
+              model = widget.model as IAIChatModel;
             }
           });
         } else {
-          model = (tracker.currentWidget?.model as AIChatModel) ?? null;
+          model = (tracker.currentWidget?.model as IAIChatModel) ?? null;
         }
         if (model === null) {
           console.warn('There is no chat to restore');

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -682,7 +682,7 @@ export interface IAIChatModel extends IChatModel {
   /**
    * A signal emitting when the chat name has changed.
    */
-  nameChanged: ISignal<IAIChatModel, string>;
+  readonly nameChanged: ISignal<IAIChatModel, string>;
   /**
    * The title of the chat.
    */
@@ -706,7 +706,7 @@ export interface IAIChatModel extends IChatModel {
   /**
    * A signal emitting when the token usage changed.
    */
-  tokenUsageChanged: ISignal<IAgentManager, ITokenUsage>;
+  readonly tokenUsageChanged: ISignal<IAgentManager, ITokenUsage>;
   /**
    * The agent manager used in the model.
    */

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,4 +1,4 @@
-import { ActiveCellManager, IMessage } from '@jupyter/chat';
+import { ActiveCellManager, IChatModel, IMessage } from '@jupyter/chat';
 import { VDomRenderer } from '@jupyterlab/apputils';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { Token } from '@lumino/coreutils';
@@ -8,7 +8,6 @@ import type { Tool, LanguageModel, UserContent, ModelMessage } from 'ai';
 import { ISecretsManager } from 'jupyter-secrets-manager';
 
 import type { IModelOptions } from './providers/models';
-import { AIChatModel } from './chat-model';
 import type {
   ISkillDefinition,
   ISkillRegistration,
@@ -679,6 +678,56 @@ export const IAgentManagerFactory = new Token<IAgentManagerFactory>(
 
 /* THE CHAT MODELS HANDLER */
 
+export interface IAIChatModel extends IChatModel {
+  /**
+   * A signal emitting when the chat name has changed.
+   */
+  nameChanged: ISignal<IAIChatModel, string>;
+  /**
+   * The title of the chat.
+   */
+  title: string | null;
+  /**
+   * A signal emitting when the chat title has changed.
+   */
+  readonly titleChanged: ISignal<IAIChatModel, string | null>;
+  /**
+   * Whether to save the chat automatically.
+   */
+  autosave: boolean;
+  /**
+   * A signal emitting when the autosave flag changed.
+   */
+  readonly autosaveChanged: ISignal<IAIChatModel, boolean>;
+  /**
+   * Whether save/restore is available.
+   */
+  readonly saveAvailable: boolean;
+  /**
+   * A signal emitting when the token usage changed.
+   */
+  tokenUsageChanged: ISignal<IAgentManager, ITokenUsage>;
+  /**
+   * The agent manager used in the model.
+   */
+  readonly agentManager: IAgentManager;
+  /**
+   * Save the chat as json file.
+   */
+  save(): Promise<void>;
+  /**
+   * Restore the chat from a json file.
+   *
+   * @param silent - Whether a log should be displayed in the console if the
+   * restoration is not possible.
+   */
+  restore(filepath: string, silent?: boolean): Promise<boolean>;
+  /**
+   * Request a title to this chat, regarding the message history.
+   */
+  requestTitle(): Promise<string>;
+}
+
 /**
  * The interface for the chat model handler.
  */
@@ -686,7 +735,7 @@ export interface IChatModelHandler {
   /**
    * The function to create a new model.
    */
-  createModel(options: ICreateChatOptions): AIChatModel;
+  createModel(options: ICreateChatOptions): IAIChatModel;
   /**
    * The active cell manager (to copy code from chat to cell).
    */

--- a/src/widgets/main-area-chat.ts
+++ b/src/widgets/main-area-chat.ts
@@ -4,7 +4,6 @@ import { launchIcon } from '@jupyterlab/ui-components';
 import type { TranslationBundle } from '@jupyterlab/translation';
 import { CommandRegistry } from '@lumino/commands';
 
-import { AIChatModel } from '../chat-model';
 import { SaveComponentWidget } from '../components/save-button';
 import { UsageWidget } from '../components/usage-display';
 import { RenderedMessageOutputAreaCompat } from '../rendered-message-outputarea';

--- a/src/widgets/main-area-chat.ts
+++ b/src/widgets/main-area-chat.ts
@@ -8,7 +8,7 @@ import { AIChatModel } from '../chat-model';
 import { SaveComponentWidget } from '../components/save-button';
 import { UsageWidget } from '../components/usage-display';
 import { RenderedMessageOutputAreaCompat } from '../rendered-message-outputarea';
-import { CommandIds, type IAISettingsModel } from '../tokens';
+import { CommandIds, IAIChatModel, type IAISettingsModel } from '../tokens';
 
 export namespace MainAreaChat {
   export interface IOptions extends MainAreaWidget.IOptions<ChatWidget> {
@@ -69,7 +69,7 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
       chatPanel: this.content
     });
 
-    this.model.writersChanged.connect(this._writersChanged);
+    this.model.writersChanged?.connect(this._writersChanged);
 
     this.model.titleChanged.connect(this._titleChanged);
   }
@@ -78,14 +78,14 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
     super.dispose();
     // Dispose of the approval buttons widget when the chat is disposed.
     this._outputAreaCompat.dispose();
-    this.model.writersChanged.disconnect(this._writersChanged);
+    this.model.writersChanged?.disconnect(this._writersChanged);
     this.model.titleChanged.disconnect(this._titleChanged);
   }
 
   /**
    * Get the model of the chat.
    */
-  get model(): AIChatModel {
+  get model(): IAIChatModel {
     return this.content.model as AIChatModel;
   }
 

--- a/src/widgets/main-area-chat.ts
+++ b/src/widgets/main-area-chat.ts
@@ -86,7 +86,7 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
    * Get the model of the chat.
    */
   get model(): IAIChatModel {
-    return this.content.model as AIChatModel;
+    return this.content.model as IAIChatModel;
   }
 
   /**


### PR DESCRIPTION
This PR exports a new interface for the `AIChatModel` object.
Currently the `AIChatModel` was not exported, which result in some difficulties to work with.
For example, the chat tracker model could not be cast, therefore some features were not available (save, restore...) from a third party extension. This avoid casting the model as `any`.
