### PR TITLE
Save the chat when autosave is updated

### DIFF
--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -167,6 +167,9 @@ export class AIChatModel extends AbstractChatModel {
     return this._autosave;
   }
   set autosave(value: boolean) {
+    if (value === this._autosave) {
+      return;
+    }
     this._autosave = value;
     this._autosaveChanged.emit(value);
     if (value) {
@@ -178,7 +181,6 @@ export class AIChatModel extends AbstractChatModel {
         this._autosaveDebouncer.invoke,
         this._autosaveDebouncer
       );
-      this._autosaveDebouncer.invoke();
     } else {
       this.messagesUpdated.disconnect(
         this._autosaveDebouncer.invoke,
@@ -189,6 +191,7 @@ export class AIChatModel extends AbstractChatModel {
         this._autosaveDebouncer
       );
     }
+    this._autosaveDebouncer.invoke();
   }
 
   /**


### PR DESCRIPTION
Before this PR, the chat was not saved when autosaved was unset.
Since the autosave state is also saved in file, this led to inconsistencies when reloading the chat.