### PR TITLE
Title follow up

### DIFF
--- a/schema/settings-model.json
+++ b/schema/settings-model.json
@@ -210,6 +210,12 @@
       "type": "boolean",
       "default": false
     },
+    "autoTitle": {
+      "title": "Auto Title",
+      "description": "Automatically request a title from the model for every message until there are 5 messages",
+      "type": "boolean",
+      "default": false
+    },
     "showTokenUsage": {
       "title": "Show Token Usage",
       "description": "Display token usage information in the chat toolbar",

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -481,7 +481,7 @@ export class AIChatModel extends AbstractChatModel {
       {
         role: 'system',
         content:
-          "Generate a concise title (no more than 10 words) for the following conversation. Do not use formatting. Focus on the user's main intent."
+          "Generate a concise title (no more than 10 words) for the following conversation. Do not use formatting, quotes, or punctuation. Focus on the subject matter and specific content the user is working on, not on the actions taken (e.g. prefer 'Pandas DataFrame filtering' over 'Opening a notebook'). The title should be a noun phrase describing the topic."
       },
       {
         role: 'user',

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -265,6 +265,7 @@ export class AIChatModel extends AbstractChatModel {
    */
   clearMessages = async (): Promise<void> => {
     this.messagesDeleted(0, this.messages.length);
+    this.title = null;
     this._toolContexts.clear();
     await this._agentManager.clearHistory();
   };

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -349,6 +349,8 @@ export class AIChatModel extends AbstractChatModel {
 
       await this._agentManager.generateResponse(enhancedMessage);
 
+      this.updateWriters([]);
+
       if (
         this._settingsModel.config.autoTitle &&
         (this.messages.length <= 5 || this.title === null)

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -348,6 +348,17 @@ export class AIChatModel extends AbstractChatModel {
       this.updateWriters([{ user: this._getAIUser() }]);
 
       await this._agentManager.generateResponse(enhancedMessage);
+
+      if (
+        this._settingsModel.config.autoTitle &&
+        (this.messages.length <= 5 || this.title === null)
+      ) {
+        try {
+          this.title = await this.requestTitle();
+        } catch {
+          // ignore title generation failures
+        }
+      }
     } catch (error) {
       const errorMessage: IMessageContent = {
         body: `Error generating AI response: ${(error as Error).message}`,

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -367,8 +367,8 @@ export class AIChatModel extends AbstractChatModel {
       ) {
         try {
           this.title = await this.requestTitle();
-        } catch {
-          // ignore title generation failures
+        } catch (e) {
+          console.warn('Error while generating a title\n', e);
         }
       }
     }

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -348,19 +348,6 @@ export class AIChatModel extends AbstractChatModel {
       this.updateWriters([{ user: this._getAIUser() }]);
 
       await this._agentManager.generateResponse(enhancedMessage);
-
-      this.updateWriters([]);
-
-      if (
-        this._settingsModel.config.autoTitle &&
-        (this.messages.length <= 5 || this.title === null)
-      ) {
-        try {
-          this.title = await this.requestTitle();
-        } catch {
-          // ignore title generation failures
-        }
-      }
     } catch (error) {
       const errorMessage: IMessageContent = {
         body: `Error generating AI response: ${(error as Error).message}`,
@@ -373,6 +360,17 @@ export class AIChatModel extends AbstractChatModel {
       this.messageAdded(errorMessage);
     } finally {
       this.updateWriters([]);
+
+      if (
+        this._settingsModel.config.autoTitle &&
+        (this.messages.length <= 5 || this.title === null)
+      ) {
+        try {
+          this.title = await this.requestTitle();
+        } catch {
+          // ignore title generation failures
+        }
+      }
     }
   }
 

--- a/src/models/settings-model.ts
+++ b/src/models/settings-model.ts
@@ -29,6 +29,7 @@ export class AISettingsModel extends VDomModel implements IAISettingsModel {
     diffDisplayMode: 'split',
     skillsPaths: ['.agents/skills', '_agents/skills'],
     chatBackupDirectory: '',
+    autoTitle: false,
     commandsRequiringApproval: [
       'notebook:restart-run-all',
       'notebook:run-cell',

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -398,6 +398,8 @@ export interface IAIConfig {
   skillsPaths: string[];
   // Directory where chat backups are saved
   chatBackupDirectory: string;
+  // Automatically request a title from the model for every message until there are 5 messages
+  autoTitle: boolean;
 }
 
 export interface IAISettingsModel extends VDomRenderer.IModel {

--- a/src/widgets/ai-settings.tsx
+++ b/src/widgets/ai-settings.tsx
@@ -928,6 +928,32 @@ const AISettingsComponent: React.FC<IAISettingsComponentProps> = ({
                 <FormControlLabel
                   control={
                     <Switch
+                      checked={config.autoTitle}
+                      onChange={e =>
+                        handleConfigUpdate({
+                          autoTitle: e.target.checked
+                        })
+                      }
+                      color="primary"
+                    />
+                  }
+                  label={
+                    <Box>
+                      <Typography variant="body1">
+                        {trans.__('Auto Title')}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {trans.__(
+                          'Automatically generate a chat title from the model for every message until there are 5 messages'
+                        )}
+                      </Typography>
+                    </Box>
+                  }
+                />
+
+                <FormControlLabel
+                  control={
+                    <Switch
                       checked={config.showTokenUsage}
                       onChange={e =>
                         handleConfigUpdate({


### PR DESCRIPTION
This PR follows up #327 
- remove the previous title when the messages are cleared
- add a setting to automatically request a title for every message until 5
- enhance the prompt when requesting the title, to focus on subject instead of actions