### PR TITLE
Rename the project to `jovia`

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -6,9 +6,9 @@ author_name: JupyterLite Contributors
 has_binder: false
 has_settings: true
 kind: frontend
-labextension_name: @jupyterlite/ai
+labextension_name: '@jovia/extension'
 project_short_description: AI code completions and chat for JupyterLite
-python_name: jupyterlite_ai
+python_name: jovia
 repository: https://github.com/jupyterlite/ai
 test: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         python -m pip install .[test]
 
         jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "@jupyterlite/ai.*OK"
+        jupyter labextension list 2>&1 | grep -ie "@jovia/extension.*OK"
         python -m jupyterlab.browser_check
 
     - name: Package the extension
@@ -45,13 +45,13 @@ jobs:
 
         pip install build
         python -m build
-        pip uninstall -y "jupyterlite_ai" jupyterlab
+        pip uninstall -y "jovia" jupyterlab
 
     - name: Upload extension packages
       uses: actions/upload-artifact@v4
       with:
         name: extension-artifacts
-        path: dist/jupyterlite_ai*
+        path: dist/jovia*
         if-no-files-found: error
 
   test_isolated:
@@ -77,11 +77,11 @@ jobs:
         sudo rm -rf $(which node)
         sudo rm -rf $(which node)
 
-        pip install "jupyterlab>=4.0.0,<5" jupyterlite_ai*.whl
+        pip install "jupyterlab>=4.0.0,<5" jovia*.whl
 
 
         jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "@jupyterlite/ai.*OK"
+        jupyter labextension list 2>&1 | grep -ie "@jovia/extension.*OK"
         python -m jupyterlab.browser_check --no-browser-test
 
   check_links:

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Upload Distributions
         uses: actions/upload-artifact@v4
         with:
-          name: jupyterlite_ai-releaser-dist-${{ github.run_number }}
+          name: jovia-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jupyterlite-ai-ui-tests-report-${{ github.run_id }}
+          name: jovia-ui-tests-report-${{ github.run_id }}
           path: |
             ui-tests/test-results
             ui-tests/playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@ node_modules/
 *.egg-info/
 .ipynb_checkpoints
 *.tsbuildinfo
-jupyterlite_ai/labextension
+jovia/labextension
 # Version file is handled by hatchling
-jupyterlite_ai/_version.py
+jovia/_version.py
 
 # Created by https://www.gitignore.io/api/python
 # Edit at https://www.gitignore.io/?templates=python

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,5 @@ node_modules
 **/lib
 **/package.json
 !/package.json
-jupyterlite_ai
+jovia
 .venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ jlpm docs:build
 ## Development uninstall
 
 ```bash
-pip uninstall jupyterlite-ai
+pip uninstall jovia
 ```
 
 In development mode, you will also need to remove the symlink created by `jupyter labextension develop`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The `jlpm` command is JupyterLab's pinned version of
 
 ```bash
 # Clone the repo to your local environment
-# Change directory to the jupyterlite_ai directory
+# Change directory to the jovia directory
 # Install package in development mode
 pip install -e "."
 # Link your development version of the extension with JupyterLab
@@ -103,7 +103,7 @@ pip uninstall jupyterlite-ai
 
 In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
 command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
-folder is located. Then you can remove the symlink named `@jupyterlite/ai` within that folder.
+folder is located. Then you can remove the symlink named `@jovia/extension` within that folder.
 
 ## Packaging the extension
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jupyterlite-ai
+# jovia
 
 [![Github Actions Status](https://github.com/jupyterlite/ai/workflows/Build/badge.svg)](https://github.com/jupyterlite/ai/actions/workflows/build.yml)
 [![Documentation Status](https://readthedocs.org/projects/jupyterlite-ai/badge/?version=latest)](https://jupyterlite-ai.readthedocs.io/en/latest/?badge=latest)
@@ -23,13 +23,13 @@ You can try the extension in your browser using JupyterLite:
 To install the extension, execute:
 
 ```bash
-pip install jupyterlite-ai
+pip install jovia
 ```
 
 To install requirements (JupyterLab, JupyterLite and Notebook):
 
 ```bash
-pip install jupyterlite-ai[jupyter]
+pip install jovia[jupyter]
 ```
 
 ## Documentation
@@ -41,7 +41,7 @@ For detailed usage instructions, including how to configure AI providers, see th
 To remove the extension, execute:
 
 ```bash
-pip uninstall jupyterlite-ai
+pip uninstall jovia
 ```
 
 ## Contributing

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Making a new release of jupyterlite_ai
+# Making a new release of jovia
 
 The extension can be published to `PyPI` and `npm` manually or using the [Jupyter Releaser](https://github.com/jupyter-server/jupyter_releaser).
 

--- a/demo/pyproject.toml
+++ b/demo/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "jupyterlite-ai-demo"
+name = "jovia-demo"
 version = "0.1.0"
-description = "JupyterLite AI Demo"
+description = "Jovia Demo"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
@@ -9,10 +9,10 @@ dependencies = [
     "jupyterlab>=4.5.0",
     "jupyterlab-day>=0.2.0",
     "jupyterlab-night>=0.5.2",
-    "jupyterlite-ai",
+    "jovia",
     "jupyterlite-core>=0.7.0",
     "jupyterlite-pyodide-kernel>=0.7.0",
 ]
 
 [tool.uv.sources]
-jupyterlite-ai = { path = "../" }
+jovia = { path = "../" }

--- a/demo/uv.lock
+++ b/demo/uv.lock
@@ -684,6 +684,54 @@ wheels = [
 ]
 
 [[package]]
+name = "jovia"
+source = { directory = "../" }
+dependencies = [
+    { name = "jupyter-chat-components" },
+    { name = "jupyter-secrets-manager" },
+    { name = "jupyterlab-ai-commands" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", marker = "extra == 'test'", specifier = ">=3.2.3,<4" },
+    { name = "jupyter-book", marker = "extra == 'docs'" },
+    { name = "jupyter-chat-components", specifier = ">=0.5.0,<0.6" },
+    { name = "jupyter-secrets-manager", specifier = ">=0.5,<0.6" },
+    { name = "jupyterlab", marker = "extra == 'jupyter'", specifier = ">=4.4.0" },
+    { name = "jupyterlab-ai-commands", specifier = ">=0.3.1,<0.4" },
+    { name = "jupyterlite", marker = "extra == 'jupyter'", specifier = ">=0.6.0" },
+    { name = "notebook", marker = "extra == 'jupyter'", specifier = ">=7.4.0" },
+    { name = "starlette", marker = "extra == 'test'", specifier = ">=0.48.0,<0.49" },
+]
+provides-extras = ["docs", "jupyter", "test"]
+
+[[package]]
+name = "jovia-demo"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "ipywidgets" },
+    { name = "jovia" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-day" },
+    { name = "jupyterlab-night" },
+    { name = "jupyterlite-core" },
+    { name = "jupyterlite-pyodide-kernel" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "ipywidgets", specifier = ">=8.1.7" },
+    { name = "jovia", directory = "../" },
+    { name = "jupyterlab", specifier = ">=4.5.0" },
+    { name = "jupyterlab-day", specifier = ">=0.2.0" },
+    { name = "jupyterlab-night", specifier = ">=0.5.2" },
+    { name = "jupyterlite-core", specifier = ">=0.7.0" },
+    { name = "jupyterlite-pyodide-kernel", specifier = ">=0.7.0" },
+]
+
+[[package]]
 name = "json5"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -985,54 +1033,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
-]
-
-[[package]]
-name = "jupyterlite-ai"
-source = { directory = "../" }
-dependencies = [
-    { name = "jupyter-chat-components" },
-    { name = "jupyter-secrets-manager" },
-    { name = "jupyterlab-ai-commands" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastmcp", marker = "extra == 'test'", specifier = ">=3.2.3,<4" },
-    { name = "jupyter-book", marker = "extra == 'docs'" },
-    { name = "jupyter-chat-components", specifier = ">=0.5.0,<0.6" },
-    { name = "jupyter-secrets-manager", specifier = ">=0.5,<0.6" },
-    { name = "jupyterlab", marker = "extra == 'jupyter'", specifier = ">=4.4.0" },
-    { name = "jupyterlab-ai-commands", specifier = ">=0.3.1,<0.4" },
-    { name = "jupyterlite", marker = "extra == 'jupyter'", specifier = ">=0.6.0" },
-    { name = "notebook", marker = "extra == 'jupyter'", specifier = ">=7.4.0" },
-    { name = "starlette", marker = "extra == 'test'", specifier = ">=0.48.0,<0.49" },
-]
-provides-extras = ["docs", "jupyter", "test"]
-
-[[package]]
-name = "jupyterlite-ai-demo"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "ipywidgets" },
-    { name = "jupyterlab" },
-    { name = "jupyterlab-day" },
-    { name = "jupyterlab-night" },
-    { name = "jupyterlite-ai" },
-    { name = "jupyterlite-core" },
-    { name = "jupyterlite-pyodide-kernel" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "ipywidgets", specifier = ">=8.1.7" },
-    { name = "jupyterlab", specifier = ">=4.5.0" },
-    { name = "jupyterlab-day", specifier = ">=0.2.0" },
-    { name = "jupyterlab-night", specifier = ">=0.5.2" },
-    { name = "jupyterlite-ai", directory = "../" },
-    { name = "jupyterlite-core", specifier = ">=0.7.0" },
-    { name = "jupyterlite-pyodide-kernel", specifier = ">=0.7.0" },
 ]
 
 [[package]]

--- a/docs/any-llm-gateway.md
+++ b/docs/any-llm-gateway.md
@@ -27,7 +27,7 @@ curl http://localhost:8000/health
 # Expected: {"status": "healthy"}
 ```
 
-## Configuring jupyterlite-ai to use any-llm-gateway
+## Configuring jovia to use any-llm-gateway
 
 Configure the [Generic provider (OpenAI-compatible)](./usage.md#using-a-generic-openai-compatible-provider) with the following settings:
 
@@ -36,16 +36,16 @@ Configure the [Generic provider (OpenAI-compatible)](./usage.md#using-a-generic-
 - **API Key**: Your gateway virtual API key
 
 :::{tip}
-**Using virtual API keys**: The master key requires a `user` field in each request, which the generic OpenAI provider doesn't send by default. To use the gateway seamlessly with jupyterlite-ai, create a virtual API key:
+**Using virtual API keys**: The master key requires a `user` field in each request, which the generic OpenAI provider doesn't send by default. To use the gateway seamlessly with jovia, create a virtual API key:
 
 ```bash
 curl -X POST http://localhost:8000/v1/keys \
   -H "Authorization: Bearer ${GATEWAY_MASTER_KEY}" \
   -H "Content-Type: application/json" \
-  -d '{"key_name": "jupyterlite-ai"}'
+  -d '{"key_name": "jovia"}'
 ```
 
-The response will contain a key starting with `gw-`. Use this virtual key as your API key in jupyterlite-ai. Virtual keys automatically track usage without requiring the `user` field.
+The response will contain a key starting with `gw-`. Use this virtual key as your API key in jovia. Virtual keys automatically track usage without requiring the `user` field.
 :::
 
 :::{note}

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -1,6 +1,6 @@
 # API Key Management
 
-To avoid storing the API keys in the settings, `jupyterlite-ai` uses [jupyter-secrets-manager](https://github.com/jupyterlab-contrib/jupyter-secrets-manager) by default.
+To avoid storing the API keys in the settings, `jovia` uses [jupyter-secrets-manager](https://github.com/jupyterlab-contrib/jupyter-secrets-manager) by default.
 
 The secrets manager gets the API keys from a connector in a secure way.
 The default connector of the secrets manager is _in memory_, which means that **the API keys are reset when reloading the page**.

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -13,7 +13,7 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { IProviderRegistry } from '@jupyterlite/ai';
+import { IProviderRegistry } from '@jovia/extension';
 import { createOpenAI } from '@ai-sdk/openai';
 
 const plugin: JupyterFrontEndPlugin<void> = {
@@ -63,7 +63,7 @@ The provider configuration object requires the following properties:
 ## Hiding the Built-In Settings UI
 
 If your extension ships a fully configured provider and you do not want users to
-edit provider settings, disable the `@jupyterlite/ai:settings-panel` plugin.
+edit provider settings, disable the `@jovia/extension:settings-panel` plugin.
 This hides the AI settings command and the chat toolbar button without
 disabling the rest of `jupyterlite-ai`.
 
@@ -71,7 +71,7 @@ For example, in your `jupyter-config-data` or `page_config.json`:
 
 ```json
 {
-  "disabledExtensions": ["@jupyterlite/ai:settings-panel"]
+  "disabledExtensions": ["@jovia/extension:settings-panel"]
 }
 ```
 

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -1,6 +1,6 @@
 # Custom Providers
 
-`jupyterlite-ai` supports custom AI providers through its provider registry system. Third-party providers can be registered programmatically in a JupyterLab extension.
+`jovia` supports custom AI providers through its provider registry system. Third-party providers can be registered programmatically in a JupyterLab extension.
 
 Providers are based on the [AI SDK](https://ai-sdk.dev/), which provides a unified interface for working with different AI models.
 
@@ -65,7 +65,7 @@ The provider configuration object requires the following properties:
 If your extension ships a fully configured provider and you do not want users to
 edit provider settings, disable the `@jovia/extension:settings-panel` plugin.
 This hides the AI settings command and the chat toolbar button without
-disabling the rest of `jupyterlite-ai`.
+disabling the rest of `jovia`.
 
 For example, in your `jupyter-config-data` or `page_config.json`:
 
@@ -110,7 +110,7 @@ In AI SDK terms, this can be either:
 - **Provider-defined tools** (declared as provider tools in AI SDK), or
 - **Provider-executed tools** (tool helpers exposed directly by provider SDKs).
 
-In `jupyterlite-ai`, provider-hosted web tools are wired through
+In `jovia`, provider-hosted web tools are wired through
 `IProviderInfo.providerToolCapabilities`. This means custom providers can opt in
 without relying on hardcoded provider IDs.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@
 To install the extension, execute:
 
 ```bash
-pip install jupyterlite-ai
+pip install jovia
 ```
 
 ## Install with Jupyter dependencies
@@ -13,7 +13,7 @@ pip install jupyterlite-ai
 To install requirements (JupyterLab, JupyterLite and Notebook):
 
 ```bash
-pip install jupyterlite-ai[jupyter]
+pip install jovia[jupyter]
 ```
 
 ## Uninstall
@@ -21,5 +21,5 @@ pip install jupyterlite-ai[jupyter]
 To remove the extension, execute:
 
 ```bash
-pip uninstall jupyterlite-ai
+pip uninstall jovia
 ```

--- a/docs/litellm.md
+++ b/docs/litellm.md
@@ -2,7 +2,7 @@
 
 [LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) is an OpenAI-compatible proxy server that allows you to call 100+ LLMs through a unified interface.
 
-Using LiteLLM Proxy with jupyterlite-ai provides flexibility to switch between different AI providers (OpenAI, Anthropic, Google, Azure, local models, etc.) without changing your JupyterLite configuration. It's particularly useful for enterprise deployments where the proxy can be hosted within private infrastructure to manage external API calls and keep API keys server-side.
+Using LiteLLM Proxy with jovia provides flexibility to switch between different AI providers (OpenAI, Anthropic, Google, Azure, local models, etc.) without changing your JupyterLite configuration. It's particularly useful for enterprise deployments where the proxy can be hosted within private infrastructure to manage external API calls and keep API keys server-side.
 
 ## Setting up LiteLLM Proxy
 
@@ -31,7 +31,7 @@ litellm --config litellm_config.yaml
 
 The proxy will start on `http://0.0.0.0:4000` by default.
 
-## Configuring jupyterlite-ai to use LiteLLM Proxy
+## Configuring jovia to use LiteLLM Proxy
 
 Configure the [Generic provider (OpenAI-compatible)](./usage.md#using-a-generic-openai-compatible-provider) with the following settings:
 

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -2,7 +2,7 @@
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open standard that enables AI assistants to connect to external tools and data sources.
 
-With `jupyterlite-ai`, you can connect to remote MCP servers to extend the AI's capabilities with additional tools.
+With `jovia`, you can connect to remote MCP servers to extend the AI's capabilities with additional tools.
 
 ## Configuring an MCP Server
 
@@ -18,7 +18,7 @@ Once connected, the MCP server's tools will be available to the AI assistant in 
 
 ## Example MCP Servers
 
-Here are some publicly available remote MCP servers you can use with `jupyterlite-ai`:
+Here are some publicly available remote MCP servers you can use with `jovia`:
 
 ### DeepWiki
 
@@ -40,11 +40,11 @@ The GitMCP server enables the AI to fetch and understand code from GitHub reposi
 
 The MCP ecosystem is growing rapidly, with directories of available servers at places like the [MCP Servers Repository](https://github.com/modelcontextprotocol/servers).
 
-However, be aware that **most MCP servers listed in these directories will not work** with `jupyterlite-ai` due to browser constraints explained below.
+However, be aware that **most MCP servers listed in these directories will not work** with `jovia` due to browser constraints explained below.
 
 ## Browser Constraints
 
-Since `jupyterlite-ai` runs entirely in the browser, it can only connect to MCP servers that meet two requirements:
+Since `jovia` runs entirely in the browser, it can only connect to MCP servers that meet two requirements:
 
 1. **Streamable HTTP transport**: The server must support the [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) defined in the MCP specification. The vast majority of MCP servers are designed to run locally using the stdio transport, which is inaccessible from a browser.
 
@@ -63,7 +63,7 @@ If you want to add custom tools, the practical approach is to provide new Jupyte
 How it works at a high level:
 
 1. Create or install a JupyterLab extension that registers one or more commands (for example, `my-extension:run-my-tool`).
-2. `jupyterlite-ai` exposes JupyterLab commands to the model through its command tools (`discover_commands` and `execute_command`).
+2. `jovia` exposes JupyterLab commands to the model through its command tools (`discover_commands` and `execute_command`).
 3. The AI can discover your command and execute it with arguments, so the command effectively becomes an AI-usable tool.
 4. If needed, require manual confirmation for specific command IDs using the **Commands Requiring Approval** setting.
 

--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -13,7 +13,7 @@ ollama pull llama3.2
 
 3. Start the Ollama server (it typically runs on `http://localhost:11434`)
 
-## Configuring jupyterlite-ai to use Ollama
+## Configuring jovia to use Ollama
 
 1. In JupyterLab, open the AI settings panel and go to the **Providers** section
 2. Click on "Add a new provider"

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -172,7 +172,7 @@ import type {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { ISkillRegistry } from '@jupyterlite/ai';
+import { ISkillRegistry } from '@jovia/extension';
 
 // Bundled resource files (scripts, references, templates)
 const resources: Record<string, string> = {

--- a/docs/web-retrieval.md
+++ b/docs/web-retrieval.md
@@ -1,6 +1,6 @@
 # Web Retrieval
 
-`jupyterlite-ai` supports two kinds of web retrieval:
+`jovia` supports two kinds of web retrieval:
 
 1. **Local browser fetch** with the built-in `browser_fetch` tool.
 2. **Provider-hosted web tools** such as `web_search` or `web_fetch`.

--- a/install.json
+++ b/install.json
@@ -1,5 +1,5 @@
 {
   "packageManager": "python",
-  "packageName": "jupyterlite_ai",
-  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlite_ai"
+  "packageName": "jovia",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jovia"
 }

--- a/jovia/__init__.py
+++ b/jovia/__init__.py
@@ -5,12 +5,12 @@ except ImportError:
     # in editable mode with pip. It is highly recommended to install
     # the package from a stable release or in editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
     import warnings
-    warnings.warn("Importing 'jupyterlite_ai' outside a proper installation.")
+    warnings.warn("Importing 'jovia' outside a proper installation.")
     __version__ = "dev"
 
 
 def _jupyter_labextension_paths():
     return [{
         "src": "labextension",
-        "dest": "@jupyterlite/ai"
+        "dest": "@jovia/extension"
     }]

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@jupyterlite/ai",
+    "name": "@jovia/extension",
     "version": "0.18.0",
     "description": "AI code completions and chat for JupyterLite",
     "keywords": [
@@ -37,7 +37,7 @@
         "clean": "jlpm clean:lib",
         "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
         "clean:lintcache": "rimraf .eslintcache .stylelintcache",
-        "clean:labextension": "rimraf jupyterlite_ai/labextension jupyterlite_ai/_version.py",
+        "clean:labextension": "rimraf jovia/labextension jovia/_version.py",
         "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
         "eslint": "jlpm eslint:check --fix",
         "eslint:check": "eslint . --cache --ext .ts,.tsx",
@@ -130,7 +130,7 @@
     },
     "jupyterlab": {
         "extension": true,
-        "outputDir": "jupyterlite_ai/labextension",
+        "outputDir": "jovia/labextension",
         "schemaDir": "schema",
         "sharedPackages": {
             "@jupyter/chat": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version>=0
 build-backend = "hatchling.build"
 
 [project]
-name = "jupyterlite_ai"
+name = "jovia"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
@@ -51,24 +51,24 @@ source = "nodejs"
 fields = ["description", "authors", "urls"]
 
 [tool.hatch.build.targets.sdist]
-artifacts = ["jupyterlite_ai/labextension"]
+artifacts = ["jovia/labextension"]
 exclude = [".github", "binder"]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"jupyterlite_ai/labextension" = "share/jupyter/labextensions/@jupyterlite/ai"
-"install.json" = "share/jupyter/labextensions/@jupyterlite/ai/install.json"
+"jovia/labextension" = "share/jupyter/labextensions/@jovia/extension"
+"install.json" = "share/jupyter/labextensions/@jovia/extension/install.json"
 
 [tool.hatch.build.hooks.version]
-path = "jupyterlite_ai/_version.py"
+path = "jovia/_version.py"
 
 [tool.hatch.build.hooks.jupyter-builder]
 dependencies = ["hatch-jupyter-builder>=0.5"]
 build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = [
-    "jupyterlite_ai/labextension/static/style.js",
-    "jupyterlite_ai/labextension/package.json",
+    "jovia/labextension/static/style.js",
+    "jovia/labextension/package.json",
 ]
-skip-if-exists = ["jupyterlite_ai/labextension/static/style.js"]
+skip-if-exists = ["jovia/labextension/static/style.js"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 build_cmd = "build:prod"
@@ -78,7 +78,7 @@ npm = ["jlpm"]
 build_cmd = "install:extension"
 npm = ["jlpm"]
 source_dir = "src"
-build_dir = "jupyterlite_ai/labextension"
+build_dir = "jovia/labextension"
 
 [tool.jupyter-releaser.options]
 version_cmd = "hatch version"

--- a/schema/settings-model.json
+++ b/schema/settings-model.json
@@ -1,6 +1,6 @@
 {
   "jupyter.lab.shortcuts": [],
-  "jupyter.lab.setting-icon": "@jupyterlite/ai:jupyternaut",
+  "jupyter.lab.setting-icon": "@jovia/extension:jupyternaut",
   "title": "JupyterLite AI Settings",
   "description": "Configuration for JupyterLite AI extension providers, models, and behavior",
   "type": "object",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1177,7 +1177,7 @@ ${richOutputWorkflowInstruction}`;
       if (!token) {
         // This should never happen, the secrets manager should be disabled.
         console.error(
-          '@jupyterlite/ai::AgentManager error: the settings manager token is not set.\nYou should disable the the secrets manager from the AI settings.'
+          '@jovia/extension::AgentManager error: the settings manager token is not set.\nYou should disable the the secrets manager from the AI settings.'
         );
         apiKey = '';
       } else {

--- a/src/chat-commands/clear.ts
+++ b/src/chat-commands/clear.ts
@@ -3,7 +3,7 @@ import { ChatCommand, IChatCommandProvider, IInputModel } from '@jupyter/chat';
 import { AIChatModel } from '../chat-model';
 
 export class ClearCommandProvider implements IChatCommandProvider {
-  public id: string = '@jupyterlite/ai:clear-command';
+  public id: string = '@jovia/extension:clear-command';
 
   async listCommandCompletions(
     inputModel: IInputModel

--- a/src/chat-commands/skills.ts
+++ b/src/chat-commands/skills.ts
@@ -11,7 +11,7 @@ export class SkillsCommandProvider implements IChatCommandProvider {
     this._commands = options.commands;
   }
 
-  public id: string = '@jupyterlite/ai:skills-command';
+  public id: string = '@jovia/extension:skills-command';
 
   async listCommandCompletions(
     inputModel: IInputModel

--- a/src/completion/completion-provider.ts
+++ b/src/completion/completion-provider.ts
@@ -66,7 +66,7 @@ export class AICompletionProvider implements IInlineCompletionProvider {
   /**
    * The unique identifier of the provider.
    */
-  readonly identifier = '@jupyterlite/ai:completer';
+  readonly identifier = '@jovia/extension:completer';
 
   /**
    * Get the current completer name based on settings.
@@ -175,7 +175,7 @@ export class AICompletionProvider implements IInlineCompletionProvider {
       if (!token) {
         // This should never happen, the secrets manager should be disabled.
         console.error(
-          '@jupyterlite/ai::AICompletionProvider error: the settings manager token is not set.\nYou should disable the secrets manager from the AI settings.'
+          '@jovia/extension::AICompletionProvider error: the settings manager token is not set.\nYou should disable the secrets manager from the AI settings.'
         );
         apiKey = '';
       } else {

--- a/src/components/completion-status.tsx
+++ b/src/components/completion-status.tsx
@@ -4,8 +4,8 @@ import type { TranslationBundle } from '@jupyterlab/translation';
 import { jupyternautIcon } from '../icons';
 import type { IAISettingsModel } from '../tokens';
 
-const COMPLETION_STATUS_CLASS = 'jp-ai-completion-status';
-const COMPLETION_DISABLED_CLASS = 'jp-ai-completion-disabled';
+const COMPLETION_STATUS_CLASS = 'jovia-completion-status';
+const COMPLETION_DISABLED_CLASS = 'jovia-completion-disabled';
 
 /**
  * The completion status props.

--- a/src/components/save-button.tsx
+++ b/src/components/save-button.tsx
@@ -9,8 +9,8 @@ import React, { useEffect, useState } from 'react';
 
 import { IAIChatModel } from '../tokens';
 
-const COMPONENT_CLASS = 'jp-ai-SaveButton';
-const AUTOSAVE_BUTTON_CLASS = 'jp-ai-AutoSaveButton';
+const COMPONENT_CLASS = 'jovia-SaveButton';
+const AUTOSAVE_BUTTON_CLASS = 'jovia-AutoSaveButton';
 
 /**
  * Properties for the SaveButton component.

--- a/src/components/tool-select.tsx
+++ b/src/components/tool-select.tsx
@@ -21,7 +21,7 @@ import type {
   IToolRegistry
 } from '../tokens';
 
-const SELECT_ITEM_CLASS = 'jp-AIToolSelect-item';
+const SELECT_ITEM_CLASS = 'jovia-ToolSelect-item';
 
 /**
  * Properties for the tool select component.

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -3,7 +3,7 @@ import { LabIcon } from '@jupyterlab/ui-components';
 import jupyternautSvg from '../style/icons/jupyternaut-lite.svg';
 
 export const jupyternautIcon = new LabIcon({
-  name: '@jupyterlite/ai:jupyternaut',
+  name: '@jovia/extension:jupyternaut',
   svgstr: jupyternautSvg
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1359,7 +1359,7 @@ const settingsPanelPlugin: JupyterFrontEndPlugin<void> = {
 
     const open = () => {
       let widget = Array.from(app.shell.widgets('main')).find(
-        w => w.id === 'jupyterlite-ai-settings'
+        w => w.id === 'jovia-settings'
       ) as AISettingsWidget | undefined;
 
       if (!widget) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1355,7 +1355,7 @@ const settingsPanelPlugin: JupyterFrontEndPlugin<void> = {
       trans
     });
     settingsWidget.title.icon = settingsIcon;
-    settingsWidget.title.iconClass = 'jp-ai-settings-icon';
+    settingsWidget.title.iconClass = 'jovia-settings-icon';
 
     const open = () => {
       let widget = Array.from(app.shell.widgets('main')).find(
@@ -1378,7 +1378,7 @@ const settingsPanelPlugin: JupyterFrontEndPlugin<void> = {
       label: trans.__('AI Settings'),
       caption: trans.__('Configure AI providers and behavior'),
       icon: settingsIcon,
-      iconClass: 'jp-ai-settings-icon',
+      iconClass: 'jovia-settings-icon',
       execute: () => {
         open();
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,7 @@ namespace Private {
  * Provider registry plugin
  */
 const providerRegistryPlugin: JupyterFrontEndPlugin<IProviderRegistry> = {
-  id: '@jupyterlite/ai:provider-registry',
+  id: '@jovia/extension:provider-registry',
   description: 'AI provider registry',
   autoStart: true,
   provides: IProviderRegistry,
@@ -209,7 +209,7 @@ const providerRegistryPlugin: JupyterFrontEndPlugin<IProviderRegistry> = {
  * Anthropic provider plugin
  */
 const anthropicProviderPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:anthropic-provider',
+  id: '@jovia/extension:anthropic-provider',
   description: 'Register Anthropic provider',
   autoStart: true,
   requires: [IProviderRegistry],
@@ -222,7 +222,7 @@ const anthropicProviderPlugin: JupyterFrontEndPlugin<void> = {
  * Google provider plugin
  */
 const googleProviderPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:google-provider',
+  id: '@jovia/extension:google-provider',
   description: 'Register Google Generative AI provider',
   autoStart: true,
   requires: [IProviderRegistry],
@@ -235,7 +235,7 @@ const googleProviderPlugin: JupyterFrontEndPlugin<void> = {
  * Mistral provider plugin
  */
 const mistralProviderPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:mistral-provider',
+  id: '@jovia/extension:mistral-provider',
   description: 'Register Mistral provider',
   autoStart: true,
   requires: [IProviderRegistry],
@@ -248,7 +248,7 @@ const mistralProviderPlugin: JupyterFrontEndPlugin<void> = {
  * OpenAI provider plugin
  */
 const openaiProviderPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:openai-provider',
+  id: '@jovia/extension:openai-provider',
   description: 'Register OpenAI provider',
   autoStart: true,
   requires: [IProviderRegistry],
@@ -261,7 +261,7 @@ const openaiProviderPlugin: JupyterFrontEndPlugin<void> = {
  * Generic provider plugin
  */
 const genericProviderPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:generic-provider',
+  id: '@jovia/extension:generic-provider',
   description: 'Register Generic OpenAI-compatible provider',
   autoStart: true,
   requires: [IProviderRegistry],
@@ -274,7 +274,7 @@ const genericProviderPlugin: JupyterFrontEndPlugin<void> = {
  * Chat command registry plugin.
  */
 const chatCommandRegistryPlugin: JupyterFrontEndPlugin<IChatCommandRegistry> = {
-  id: '@jupyterlite/ai:chat-command-registry',
+  id: '@jovia/extension:chat-command-registry',
   description: 'Provide the chat command registry for JupyterLite AI.',
   autoStart: true,
   provides: IChatCommandRegistry,
@@ -287,7 +287,7 @@ const chatCommandRegistryPlugin: JupyterFrontEndPlugin<IChatCommandRegistry> = {
  * Clear chat command plugin.
  */
 const clearCommandPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:clear-command',
+  id: '@jovia/extension:clear-command',
   description: 'Register the /clear chat command.',
   autoStart: true,
   requires: [IChatCommandRegistry],
@@ -300,7 +300,7 @@ const clearCommandPlugin: JupyterFrontEndPlugin<void> = {
  * Skills chat command plugin.
  */
 const skillsCommandPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:skills-command',
+  id: '@jovia/extension:skills-command',
   description: 'Register the /skills chat command.',
   autoStart: true,
   requires: [IChatCommandRegistry, ISkillRegistry],
@@ -322,7 +322,7 @@ const skillsCommandPlugin: JupyterFrontEndPlugin<void> = {
  * The chat model handler.
  */
 const chatModelHandler: JupyterFrontEndPlugin<IChatModelHandler> = {
-  id: '@jupyterlite/ai:chat-model-handler',
+  id: '@jovia/extension:chat-model-handler',
   description: 'A handler to create current chat model',
   autoStart: true,
   requires: [
@@ -360,7 +360,7 @@ const chatModelHandler: JupyterFrontEndPlugin<IChatModelHandler> = {
  * The active cell manager plugin, to allow copying code from chat to notebook.
  */
 const activeCellManager: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:activeCellManager',
+  id: '@jovia/extension:activeCellManager',
   description: 'Add the active cell manager to the model handler',
   autoStart: true,
   requires: [IChatModelHandler, INotebookTracker],
@@ -381,7 +381,7 @@ const activeCellManager: JupyterFrontEndPlugin<void> = {
  * Initialization data for the extension.
  */
 const plugin: JupyterFrontEndPlugin<IChatTracker> = {
-  id: '@jupyterlite/ai:plugin',
+  id: '@jovia/extension:plugin',
   description: 'AI in JupyterLab',
   autoStart: true,
   provides: IChatTracker,
@@ -416,7 +416,7 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
     palette?: ICommandPalette,
     documentManager?: IDocumentManager
   ): IChatTracker => {
-    const trans = (translator ?? nullTranslator).load('jupyterlite_ai');
+    const trans = (translator ?? nullTranslator).load('jovia');
 
     // Create attachment opener registry to handle file attachments
     const attachmentOpenerRegistry = new AttachmentOpenerRegistry();
@@ -484,7 +484,7 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
         }) as Promise<boolean>
     });
 
-    chatPanel.id = '@jupyterlite/ai:chat-panel';
+    chatPanel.id = '@jovia/extension:chat-panel';
     chatPanel.title.icon = chatIcon;
     chatPanel.title.caption = trans.__('Chat with AI assistant');
 
@@ -1321,7 +1321,7 @@ const agentManagerFactory: JupyterFrontEndPlugin<IAgentManagerFactory> =
  * AI settings panel plugin.
  */
 const settingsPanelPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:settings-panel',
+  id: '@jovia/extension:settings-panel',
   description: 'Provide the AI settings panel',
   autoStart: true,
   requires: [IAISettingsModel, IAgentManagerFactory, IProviderRegistry],
@@ -1343,7 +1343,7 @@ const settingsPanelPlugin: JupyterFrontEndPlugin<void> = {
     themeManager?: IThemeManager,
     translator?: ITranslator
   ): void => {
-    const trans = (translator ?? nullTranslator).load('jupyterlite_ai');
+    const trans = (translator ?? nullTranslator).load('jovia');
     const secretsAccess = Private.createAISecretsAccess(secretsManager);
 
     const settingsWidget = new AISettingsWidget({
@@ -1400,7 +1400,7 @@ const settingsPanelPlugin: JupyterFrontEndPlugin<void> = {
  * Built-in completion providers plugin
  */
 const settingsModel: JupyterFrontEndPlugin<IAISettingsModel> = {
-  id: '@jupyterlite/ai:settings-model',
+  id: '@jovia/extension:settings-model',
   description: 'Provide the AI settings model',
   autoStart: true,
   provides: IAISettingsModel,
@@ -1417,7 +1417,7 @@ const settingsModel: JupyterFrontEndPlugin<IAISettingsModel> = {
  * Diff manager plugin
  */
 const diffManager: JupyterFrontEndPlugin<IDiffManager> = {
-  id: '@jupyterlite/ai:diff-manager',
+  id: '@jovia/extension:diff-manager',
   description: 'Provide the diff manager for notebook cell diffs',
   autoStart: true,
   provides: IDiffManager,
@@ -1437,7 +1437,7 @@ const diffManager: JupyterFrontEndPlugin<IDiffManager> = {
  * Skill registry plugin
  */
 const skillRegistryPlugin: JupyterFrontEndPlugin<ISkillRegistry> = {
-  id: '@jupyterlite/ai:skill-registry',
+  id: '@jovia/extension:skill-registry',
   description: 'Provide the skill registry',
   autoStart: true,
   provides: ISkillRegistry,
@@ -1447,7 +1447,7 @@ const skillRegistryPlugin: JupyterFrontEndPlugin<ISkillRegistry> = {
 };
 
 const toolRegistry: JupyterFrontEndPlugin<IToolRegistry> = {
-  id: '@jupyterlite/ai:tool-registry',
+  id: '@jovia/extension:tool-registry',
   description: 'Provide the AI tool registry',
   autoStart: true,
   requires: [IAISettingsModel],
@@ -1487,7 +1487,7 @@ const toolRegistry: JupyterFrontEndPlugin<IToolRegistry> = {
  */
 const inputToolbarFactory: JupyterFrontEndPlugin<IInputToolbarRegistryFactory> =
   {
-    id: '@jupyterlite/ai:input-toolbar-factory',
+    id: '@jovia/extension:input-toolbar-factory',
     description: 'The input toolbar registry plugin.',
     autoStart: true,
     provides: IInputToolbarRegistryFactory,
@@ -1500,7 +1500,7 @@ const inputToolbarFactory: JupyterFrontEndPlugin<IInputToolbarRegistryFactory> =
       providerRegistry: IProviderRegistry,
       translator?: ITranslator
     ): IInputToolbarRegistryFactory => {
-      const trans = (translator ?? nullTranslator).load('jupyterlite_ai');
+      const trans = (translator ?? nullTranslator).load('jovia');
       const stopButton = stopItem(trans);
       const clearButton = clearItem(trans);
       const toolSelectButton = createToolSelectItem(
@@ -1538,7 +1538,7 @@ const inputToolbarFactory: JupyterFrontEndPlugin<IInputToolbarRegistryFactory> =
   };
 
 const completionStatus: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:completion-status',
+  id: '@jovia/extension:completion-status',
   description: 'The completion status displayed in the status bar',
   autoStart: true,
   requires: [IAISettingsModel],
@@ -1552,7 +1552,7 @@ const completionStatus: JupyterFrontEndPlugin<void> = {
     if (!statusBar) {
       return;
     }
-    const trans = (translator ?? nullTranslator).load('jupyterlite_ai');
+    const trans = (translator ?? nullTranslator).load('jovia');
     const item = new CompletionStatusWidget({
       settingsModel,
       translator: trans
@@ -1569,7 +1569,7 @@ const completionStatus: JupyterFrontEndPlugin<void> = {
  * Skills plugin: discovers and registers agent skills from the filesystem.
  */
 const skillsPlugin: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlite/ai:skills',
+  id: '@jovia/extension:skills',
   description: 'Discover and register agent skills',
   autoStart: true,
   requires: [IAISettingsModel, IDocumentManager, ISkillRegistry],
@@ -1582,7 +1582,7 @@ const skillsPlugin: JupyterFrontEndPlugin<void> = {
     palette?: ICommandPalette,
     translator?: ITranslator
   ) => {
-    const trans = (translator ?? nullTranslator).load('jupyterlite_ai');
+    const trans = (translator ?? nullTranslator).load('jovia');
     const validateResourcePath = (resourcePath: string): string | null => {
       if (resourcePath.startsWith('/')) {
         return null;

--- a/src/models/settings-model.ts
+++ b/src/models/settings-model.ts
@@ -8,7 +8,7 @@ import {
   IProviderConfig
 } from '../tokens';
 
-const PLUGIN_ID = '@jupyterlite/ai:settings-model';
+const PLUGIN_ID = '@jovia/extension:settings-model';
 
 export class AISettingsModel extends VDomModel implements IAISettingsModel {
   private _config: IAIConfig = {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -26,14 +26,14 @@ export type {
  * Command IDs namespace
  */
 export namespace CommandIds {
-  export const openSettings = '@jupyterlite/ai:open-settings';
-  export const reposition = '@jupyterlite/ai:reposition';
-  export const openChat = '@jupyterlite/ai:open-chat';
-  export const openOrRevealChat = '@jupyterlite/ai:open-or-reveal-chat';
-  export const moveChat = '@jupyterlite/ai:move-chat';
-  export const refreshSkills = '@jupyterlite/ai:refresh-skills';
-  export const saveChat = '@jupyterlite/ai:save-chat';
-  export const restoreChat = '@jupyterlite/ai:restore-chat';
+  export const openSettings = '@jovia/extension:open-settings';
+  export const reposition = '@jovia/extension:reposition';
+  export const openChat = '@jovia/extension:open-chat';
+  export const openOrRevealChat = '@jovia/extension:open-or-reveal-chat';
+  export const moveChat = '@jovia/extension:move-chat';
+  export const refreshSkills = '@jovia/extension:refresh-skills';
+  export const saveChat = '@jovia/extension:save-chat';
+  export const restoreChat = '@jovia/extension:restore-chat';
 }
 
 /* THE TOOL REGISTRY */
@@ -102,7 +102,7 @@ export interface IToolRegistry {
  * The tool registry token.
  */
 export const IToolRegistry = new Token<IToolRegistry>(
-  '@jupyterlite/ai:IToolRegistry',
+  '@jovia/extension:IToolRegistry',
   'Tool registry for AI agent functionality'
 );
 
@@ -145,7 +145,7 @@ export interface ISkillRegistry {
  * The skill registry token.
  */
 export const ISkillRegistry = new Token<ISkillRegistry>(
-  '@jupyterlite/ai:ISkillRegistry',
+  '@jovia/extension:ISkillRegistry',
   'Skill registry for AI agent functionality'
 );
 
@@ -335,7 +335,7 @@ export interface IProviderRegistry {
  * Token for the provider registry.
  */
 export const IProviderRegistry = new Token<IProviderRegistry>(
-  '@jupyterlite/ai:IProviderRegistry',
+  '@jovia/extension:IProviderRegistry',
   'Registry for AI providers'
 );
 
@@ -445,7 +445,7 @@ export interface IAISettingsModel extends VDomRenderer.IModel {
  * Token for the AI settings model.
  */
 export const IAISettingsModel = new Token<IAISettingsModel>(
-  '@jupyterlite/ai:IAISettingsModel'
+  '@jovia/extension:IAISettingsModel'
 );
 
 /* THE AGENT MANAGER */
@@ -641,7 +641,7 @@ export interface IAgentManager {
  * Token for the agent manager.
  */
 export const IAgentManager = new Token<IAgentManager>(
-  '@jupyterlite/ai:IAgentManager'
+  '@jovia/extension:IAgentManager'
 );
 
 /* The AGENT MANAGER FACTORY */
@@ -673,7 +673,7 @@ export interface IAgentManagerFactory {
  * Token for the agent manager factory.
  */
 export const IAgentManagerFactory = new Token<IAgentManagerFactory>(
-  '@jupyterlite/ai:IAgentManagerFactory'
+  '@jovia/extension:IAgentManagerFactory'
 );
 
 /* THE CHAT MODELS HANDLER */
@@ -785,7 +785,7 @@ export interface ICreateChatOptions {
  * Token for the chat model handler.
  */
 export const IChatModelHandler = new Token<IChatModelHandler>(
-  '@jupyterlite/ai:IChatModelHandler'
+  '@jovia/extension:IChatModelHandler'
 );
 
 /* THE DIFF MANAGER */
@@ -860,7 +860,7 @@ export interface IDiffManager {
  * Token for the diff manager.
  */
 export const IDiffManager = new Token<IDiffManager>(
-  '@jupyterlite/ai:IDiffManager'
+  '@jovia/extension:IDiffManager'
 );
 
 /**
@@ -892,7 +892,7 @@ export interface ITokenUsage {
 /**
  * The string that replaces a secret key in settings.
  */
-export const SECRETS_NAMESPACE = '@jupyterlite/ai:providers';
+export const SECRETS_NAMESPACE = '@jovia/extension:providers';
 export const SECRETS_REPLACEMENT = '***';
 
 /**

--- a/src/widgets/ai-settings.tsx
+++ b/src/widgets/ai-settings.tsx
@@ -92,7 +92,7 @@ export class AISettingsWidget extends ReactWidget {
     this._providerRegistry = options.providerRegistry;
     this._secretsAccess = options.secretsAccess;
     this._trans = options.trans;
-    this.id = 'jupyterlite-ai-settings';
+    this.id = 'jovia-settings';
     this.title.label = this._trans.__('AI Settings');
     this.title.caption = this._trans.__('Configure AI providers and behavior');
     this.title.closable = true;

--- a/src/widgets/ai-settings.tsx
+++ b/src/widgets/ai-settings.tsx
@@ -602,7 +602,7 @@ const AISettingsComponent: React.FC<IAISettingsComponentProps> = ({
                         <Select
                           value={config.activeCompleterProvider || ''}
                           label={trans.__('Completion Provider')}
-                          className="jp-ai-completion-provider-select"
+                          className="jovia-completion-provider-select"
                           onChange={e =>
                             model.setActiveCompleterProvider(
                               e.target.value || undefined

--- a/style/base.css
+++ b/style/base.css
@@ -31,7 +31,7 @@
 }
 
 /* Tool Select Component Styles - Enhanced */
-.jp-AIToolSelect-item {
+.jovia-ToolSelect-item {
   display: flex;
   align-items: center;
   min-height: 36px;
@@ -39,11 +39,11 @@
   transition: background-color 0.2s ease;
 }
 
-.jp-AIToolSelect-item:hover {
+.jovia-ToolSelect-item:hover {
   background: var(--jp-layout-color2);
 }
 
-.jp-AIToolSelect-item .lm-Menu-itemIcon {
+.jovia-ToolSelect-item .lm-Menu-itemIcon {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -110,7 +110,7 @@
 }
 
 /* Save button */
-.jp-ai-SaveButton {
+.jovia-SaveButton {
   display: flex;
   align-items: center;
   background-color: var(--jp-layout-color1);
@@ -119,32 +119,32 @@
   padding: 4px;
 }
 
-.jp-ai-SaveButton.lm-mod-toggled {
+.jovia-SaveButton.lm-mod-toggled {
   box-shadow: inset 0 0 2px 2px var(--neutral-fill-strong-active);
 }
 
-.jp-ai-SaveButton .jp-ToolbarButtonComponent {
+.jovia-SaveButton .jp-ToolbarButtonComponent {
   margin: unset;
   height: 18px;
 }
 
-.jp-ai-SaveButton .jp-ai-AutoSaveButton {
+.jovia-SaveButton .jovia-AutoSaveButton {
   min-width: unset;
   width: 18px;
 }
 
-.jp-ai-SaveButton .jp-ai-AutoSaveButton svg {
+.jovia-SaveButton .jovia-AutoSaveButton svg {
   width: 12px;
   height: 12px;
 }
 
 .jp-MainAreaWidget
-  .jp-ToolbarButtonComponent[data-command='@jupyterlite/ai:move-chat']
+  .jp-ToolbarButtonComponent[data-command='@jovia/extension:move-chat']
   svg {
   transform: rotate(180deg);
 }
 
-.jp-ai-settings-icon {
+.jovia-settings-icon {
   align-items: center;
   display: flex;
 }
@@ -159,10 +159,10 @@
 }
 
 /* Disabled color for the completion status */
-.jp-ai-completion-status .jp-ai-completion-disabled circle {
+.jovia-completion-status .jovia-completion-disabled circle {
   fill: var(--jp-layout-color3);
 }
 
-.jp-ai-completion-status .jp-ai-completion-disabled path {
+.jovia-completion-status .jovia-completion-disabled path {
   fill: var(--jp-layout-color2);
 }

--- a/style/base.css
+++ b/style/base.css
@@ -52,63 +52,6 @@
   margin-right: 8px;
 }
 
-/* Enhanced tool select button styles */
-.jp-AIToolSelect-button {
-  min-width: 36px;
-  padding: 6px 8px;
-  background: var(--jp-layout-color2) !important;
-  border: 1px solid var(--jp-border-color1) !important;
-  transition: all 0.2s ease;
-}
-
-.jp-AIToolSelect-button:hover {
-  background: var(--jp-layout-color3) !important;
-  border-color: var(--jp-brand-color1) !important;
-}
-
-.jp-AIToolSelect-button[aria-expanded='true'] {
-  background: var(--jp-brand-color1) !important;
-  color: white !important;
-}
-
-/* Enhanced tool select menu styles */
-.jp-AIToolSelect-menu {
-  max-width: 300px;
-  box-shadow: var(--jp-elevation-z6);
-  border: 1px solid var(--jp-border-color2);
-}
-
-.jp-AIToolSelect-menu .MuiMenuItem-root {
-  padding: 8px 16px;
-  min-height: 40px;
-  border-bottom: 1px solid var(--jp-border-color3);
-}
-
-.jp-AIToolSelect-menu .MuiMenuItem-root:last-child {
-  border-bottom: none;
-}
-
-.jp-AIChatToolbar {
-  display: flex;
-  flex-shrink: 0;
-}
-
-.jp-AIChatWrapper {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-}
-
-.jp-AIChatPanel {
-  flex: 1;
-  min-height: 0;
-}
-
-.jp-chat-attachment {
-  border-radius: 2px;
-  padding: 0 0.4em;
-}
-
 /* Save button */
 .jovia-SaveButton {
   display: flex;

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "jupyterlite-ai-ui-tests",
+  "name": "jovia-ui-tests",
   "version": "1.0.0",
-  "description": "jupyterlite-ai Integration Tests",
+  "description": "jovia Integration Tests",
   "private": true,
   "scripts": {
     "start": "jupyter lab --config jupyter_server_test_config.py",

--- a/ui-tests/tests/browser-fetch-tool.spec.ts
+++ b/ui-tests/tests/browser-fetch-tool.spec.ts
@@ -17,8 +17,8 @@ test.use({
       fetchNews: 'false',
       doNotDisturbMode: true
     },
-    '@jupyterlite/ai:settings-model': {
-      ...DEFAULT_GENERIC_PROVIDER_SETTINGS['@jupyterlite/ai:settings-model'],
+    '@jovia/extension:settings-model': {
+      ...DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model'],
       toolsEnabled: true,
       defaultProvider: 'generic-functiongemma',
       // Keep the test deterministic with small local models.

--- a/ui-tests/tests/chat-panel.spec.ts
+++ b/ui-tests/tests/chat-panel.spec.ts
@@ -222,7 +222,7 @@ TEST_PROVIDERS.forEach(({ name, settings }) =>
       const mainAreaPanel =
         await page.activity.getPanelLocator(QWEN_MODEL_NAME);
       await mainAreaPanel
-        ?.locator('[data-command="@jupyterlite/ai:move-chat"]')
+        ?.locator('[data-command="@jovia/extension:move-chat"]')
         .click();
       await expect(chatWidgetToolbar).toBeVisible();
       await expect(mainAreaTab).toHaveCount(0);
@@ -258,7 +258,7 @@ TEST_PROVIDERS.forEach(({ name, settings }) =>
       await page.evaluate(
         ({ name, input }) => {
           return window.jupyterapp.commands.execute(
-            '@jupyterlite/ai:open-chat',
+            '@jovia/extension:open-chat',
             {
               name,
               input
@@ -283,7 +283,7 @@ TEST_PROVIDERS.forEach(({ name, settings }) =>
       await page.evaluate(
         ({ name, area, input }) => {
           return window.jupyterapp.commands.execute(
-            '@jupyterlite/ai:open-or-reveal-chat',
+            '@jovia/extension:open-or-reveal-chat',
             {
               name,
               area,
@@ -310,7 +310,7 @@ TEST_PROVIDERS.forEach(({ name, settings }) =>
       await page.evaluate(
         ({ name, area, input }) => {
           return window.jupyterapp.commands.execute(
-            '@jupyterlite/ai:open-or-reveal-chat',
+            '@jovia/extension:open-or-reveal-chat',
             {
               name,
               area,

--- a/ui-tests/tests/chat-panel.spec.ts
+++ b/ui-tests/tests/chat-panel.spec.ts
@@ -36,7 +36,7 @@ test.describe('#withoutModel', () => {
     await expect(page.locator('.jp-Dialog')).toBeVisible();
 
     // Should open the AI settings
-    await expect(page.locator('#jupyterlite-ai-settings')).toBeVisible();
+    await expect(page.locator('#jovia-settings')).toBeVisible();
   });
 });
 
@@ -151,7 +151,7 @@ TEST_PROVIDERS.forEach(({ name, settings }) =>
       const settingsButton = panel.getByTitle('Open AI Settings');
       await settingsButton.click();
 
-      const aiSettingsWidget = page.locator('#jupyterlite-ai-settings');
+      const aiSettingsWidget = page.locator('#jovia-settings');
       await expect(aiSettingsWidget).toBeVisible();
 
       // Remove the existing default provider for this test only
@@ -235,7 +235,7 @@ TEST_PROVIDERS.forEach(({ name, settings }) =>
 
       await panel.getByTitle('Open AI Settings').click();
 
-      const aiSettingsWidget = page.locator('#jupyterlite-ai-settings');
+      const aiSettingsWidget = page.locator('#jovia-settings');
       await expect(aiSettingsWidget).toBeVisible();
       await aiSettingsWidget.getByRole('tab', { name: 'Behavior' }).click();
       await aiSettingsWidget.getByLabel('Show Context Usage').click();

--- a/ui-tests/tests/chat-save-restore.spec.ts
+++ b/ui-tests/tests/chat-save-restore.spec.ts
@@ -172,7 +172,7 @@ test.describe('#chatSaveRestore', () => {
     // Update the backup directory in settings
     const settingsButton = panel.getByTitle('Open AI Settings');
     await settingsButton.click();
-    const aiSettingsWidget = page.locator('#jupyterlite-ai-settings');
+    const aiSettingsWidget = page.locator('#jovia-settings');
     await expect(aiSettingsWidget).toBeVisible();
     await aiSettingsWidget.getByText('BEHAVIOR').click();
 

--- a/ui-tests/tests/chat-save-restore.spec.ts
+++ b/ui-tests/tests/chat-save-restore.spec.ts
@@ -38,7 +38,7 @@ test.describe('#chatSaveRestore', () => {
     page
   }) => {
     const panel = await openChatPanel(page);
-    const saveContainer = panel.locator('.jp-ai-SaveButton');
+    const saveContainer = panel.locator('.jovia-SaveButton');
 
     await expect(saveContainer).toBeVisible();
     await expect(saveContainer.getByTitle('Save chat')).toBeVisible();
@@ -48,7 +48,7 @@ test.describe('#chatSaveRestore', () => {
   test('should save the chat to a backup file', async ({ page }) => {
     const panel = await openChatPanel(page);
 
-    await panel.locator('.jp-ai-SaveButton').getByTitle('Save chat').click();
+    await panel.locator('.jovia-SaveButton').getByTitle('Save chat').click();
 
     await page.waitForCondition(
       async () => await page.filebrowser.contents.fileExists(BACKUP_FILE)
@@ -57,7 +57,7 @@ test.describe('#chatSaveRestore', () => {
 
   test('should toggle auto-save on and off', async ({ page }) => {
     const panel = await openChatPanel(page);
-    const saveContainer = panel.locator('.jp-ai-SaveButton');
+    const saveContainer = panel.locator('.jovia-SaveButton');
     const autoSaveButton = saveContainer.getByTitle('Auto-save');
 
     // Initially not toggled.
@@ -86,8 +86,8 @@ test.describe('#chatSaveRestore', () => {
     );
 
     // Enable auto-save.
-    await panel.locator('.jp-ai-SaveButton').getByTitle('Auto-save').click();
-    await expect(panel.locator('.jp-ai-SaveButton')).toHaveClass(
+    await panel.locator('.jovia-SaveButton').getByTitle('Auto-save').click();
+    await expect(panel.locator('.jovia-SaveButton')).toHaveClass(
       /lm-mod-toggled/
     );
 
@@ -124,7 +124,7 @@ test.describe('#chatSaveRestore', () => {
     ).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
     // Save the chat.
-    await panel.locator('.jp-ai-SaveButton').getByTitle('Save chat').click();
+    await panel.locator('.jovia-SaveButton').getByTitle('Save chat').click();
 
     // Wait for the chat to be created.
     await page.waitForCondition(
@@ -202,7 +202,7 @@ test.describe('#chatSaveRestore', () => {
       panel.locator('.jp-chat-message-header:has-text("Jupyternaut")')
     ).toHaveCount(1, { timeout: EXPECT_TIMEOUT });
 
-    await panel.locator('.jp-ai-SaveButton').getByTitle('Save chat').click();
+    await panel.locator('.jovia-SaveButton').getByTitle('Save chat').click();
 
     await page.waitForCondition(
       async () => await page.filebrowser.contents.fileExists(backupPath)
@@ -229,7 +229,7 @@ test.describe('#chatSaveRestore', () => {
     );
 
     // Enable auto-save and send a message so there is content to save.
-    await panel.locator('.jp-ai-SaveButton').getByTitle('Auto-save').click();
+    await panel.locator('.jovia-SaveButton').getByTitle('Auto-save').click();
     await input.pressSequentially('Hello');
     await sendButton.click();
 
@@ -257,7 +257,7 @@ test.describe('#chatSaveRestore', () => {
     const reloadedPanel = await openChatPanel(page);
 
     // The auto-save state should have been restored (container toggled).
-    const saveContainer = reloadedPanel.locator('.jp-ai-SaveButton');
+    const saveContainer = reloadedPanel.locator('.jovia-SaveButton');
 
     await expect(saveContainer).toHaveClass(/lm-mod-toggled/, {
       timeout: 10000

--- a/ui-tests/tests/chat-save-restore.spec.ts
+++ b/ui-tests/tests/chat-save-restore.spec.ts
@@ -162,7 +162,7 @@ test.describe('#chatSaveRestore', () => {
     await page.evaluate(async (dir: string) => {
       const app = (window as any).jupyterapp;
       await app.serviceManager.settings.save(
-        '@jupyterlite/ai:settings-model',
+        '@jovia/extension:settings-model',
         JSON.stringify({ chatBackupDirectory: dir })
       );
     }, customDir);

--- a/ui-tests/tests/code-completion.spec.ts
+++ b/ui-tests/tests/code-completion.spec.ts
@@ -97,7 +97,7 @@ test.describe('#CompletionStatus', () => {
   });
 
   test('should have a completion status indicator', async ({ page }) => {
-    await expect(page.locator('.jp-ai-completion-status')).toBeVisible();
+    await expect(page.locator('.jovia-completion-status')).toBeVisible();
   });
 
   test('completion status indicator should be enabled', async ({ page }) => {
@@ -105,9 +105,9 @@ test.describe('#CompletionStatus', () => {
       DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model']
         .providers[0].model;
     const component = page.locator(
-      '.jp-ai-completion-status > div:first-child'
+      '.jovia-completion-status > div:first-child'
     );
-    await expect(component).not.toHaveClass(/jp-ai-completion-disabled/);
+    await expect(component).not.toHaveClass(/jovia-completion-disabled/);
     await expect(component).toHaveAttribute(
       'title',
       `Completion using ${model}`
@@ -122,7 +122,7 @@ test.describe('#CompletionStatus', () => {
       DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model']
         .providers[0].name;
     const component = page.locator(
-      '.jp-ai-completion-status > div:first-child'
+      '.jovia-completion-status > div:first-child'
     );
 
     // Open the settings panel
@@ -137,21 +137,21 @@ test.describe('#CompletionStatus', () => {
     await settingsPanel.getByRole('switch').first().click();
 
     // Expect the completion to be disabled
-    await expect(component).toHaveClass(/jp-ai-completion-disabled/);
+    await expect(component).toHaveClass(/jovia-completion-disabled/);
     await expect(component).toHaveAttribute('title', 'No completion');
 
     // Select back a model and expect the completion to be enabled
-    await settingsPanel.locator('.jp-ai-completion-provider-select').click();
+    await settingsPanel.locator('.jovia-completion-provider-select').click();
     await page.getByRole('option', { name }).click();
-    await expect(component).not.toHaveClass(/jp-ai-completion-disabled/);
+    await expect(component).not.toHaveClass(/jovia-completion-disabled/);
     await expect(component).toHaveAttribute(
       'title',
       `Completion using ${model}`
     );
 
     // Disable manually the completion
-    await settingsPanel.locator('.jp-ai-completion-provider-select').click();
+    await settingsPanel.locator('.jovia-completion-provider-select').click();
     await page.getByRole('option', { name: 'No completion' }).click();
-    await expect(component).toHaveClass(/jp-ai-completion-disabled/);
+    await expect(component).toHaveClass(/jovia-completion-disabled/);
   });
 });

--- a/ui-tests/tests/code-completion.spec.ts
+++ b/ui-tests/tests/code-completion.spec.ts
@@ -126,7 +126,7 @@ test.describe('#CompletionStatus', () => {
     );
 
     // Open the settings panel
-    const settingsPanel = page.locator('#jupyterlite-ai-settings');
+    const settingsPanel = page.locator('#jovia-settings');
     await page.keyboard.press('Control+Shift+c');
     await page
       .locator(

--- a/ui-tests/tests/code-completion.spec.ts
+++ b/ui-tests/tests/code-completion.spec.ts
@@ -102,7 +102,7 @@ test.describe('#CompletionStatus', () => {
 
   test('completion status indicator should be enabled', async ({ page }) => {
     const model =
-      DEFAULT_GENERIC_PROVIDER_SETTINGS['@jupyterlite/ai:settings-model']
+      DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model']
         .providers[0].model;
     const component = page.locator(
       '.jp-ai-completion-status > div:first-child'
@@ -116,10 +116,10 @@ test.describe('#CompletionStatus', () => {
 
   test('completion status should toggle', async ({ page }) => {
     const model =
-      DEFAULT_GENERIC_PROVIDER_SETTINGS['@jupyterlite/ai:settings-model']
+      DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model']
         .providers[0].model;
     const name =
-      DEFAULT_GENERIC_PROVIDER_SETTINGS['@jupyterlite/ai:settings-model']
+      DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model']
         .providers[0].name;
     const component = page.locator(
       '.jp-ai-completion-status > div:first-child'
@@ -130,7 +130,7 @@ test.describe('#CompletionStatus', () => {
     await page.keyboard.press('Control+Shift+c');
     await page
       .locator(
-        '#modal-command-palette li[data-command="@jupyterlite/ai:open-settings"]'
+        '#modal-command-palette li[data-command="@jovia/extension:open-settings"]'
       )
       .click();
     // Do not use the same provider for chat and completion

--- a/ui-tests/tests/commands-tool.spec.ts
+++ b/ui-tests/tests/commands-tool.spec.ts
@@ -16,8 +16,8 @@ test.use({
       fetchNews: 'false',
       doNotDisturbMode: true
     },
-    '@jupyterlite/ai:settings-model': {
-      ...DEFAULT_GENERIC_PROVIDER_SETTINGS['@jupyterlite/ai:settings-model'],
+    '@jovia/extension:settings-model': {
+      ...DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model'],
       toolsEnabled: true,
       defaultProvider: 'generic-functiongemma',
       // To nudge the model to call the tool with specific parameters

--- a/ui-tests/tests/mcp-integration.spec.ts
+++ b/ui-tests/tests/mcp-integration.spec.ts
@@ -74,7 +74,7 @@ test.describe('#mcpIntegration', () => {
     const settingsButton = panel.getByTitle('Open AI Settings');
     await settingsButton.click();
 
-    const settingsPanel = page.locator('#jupyterlite-ai-settings');
+    const settingsPanel = page.locator('#jovia-settings');
     await expect(settingsPanel).toBeVisible();
 
     const mcpServersTab = settingsPanel.getByRole('tab', {

--- a/ui-tests/tests/mcp-integration.spec.ts
+++ b/ui-tests/tests/mcp-integration.spec.ts
@@ -17,8 +17,8 @@ test.use({
       fetchNews: 'false',
       doNotDisturbMode: true
     },
-    '@jupyterlite/ai:settings-model': {
-      ...DEFAULT_GENERIC_PROVIDER_SETTINGS['@jupyterlite/ai:settings-model'],
+    '@jovia/extension:settings-model': {
+      ...DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model'],
       toolsEnabled: true,
       // To nudge the (relatively small) model to call the tools
       systemPrompt: 'Just call the tools you are asked to call',

--- a/ui-tests/tests/mime-bundles.spec.ts
+++ b/ui-tests/tests/mime-bundles.spec.ts
@@ -14,7 +14,7 @@ import { DEFAULT_GENERIC_PROVIDER_SETTINGS, openChatPanel } from './test-utils';
 const EXPECT_TIMEOUT = 120000;
 const TEST_MIME_BUNDLE_COMMAND_ID = 'jupyterlite-ai-tests:emit-mime-bundle';
 const BASE_SETTINGS =
-  DEFAULT_GENERIC_PROVIDER_SETTINGS['@jupyterlite/ai:settings-model'];
+  DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model'];
 const PROVIDERS = BASE_SETTINGS.providers.map(provider => {
   if (provider.id !== 'generic-functiongemma') {
     return provider;
@@ -36,7 +36,7 @@ test.use({
       fetchNews: 'false',
       doNotDisturbMode: true
     },
-    '@jupyterlite/ai:settings-model': {
+    '@jovia/extension:settings-model': {
       ...BASE_SETTINGS,
       providers: PROVIDERS,
       toolsEnabled: true,

--- a/ui-tests/tests/mime-bundles.spec.ts
+++ b/ui-tests/tests/mime-bundles.spec.ts
@@ -12,7 +12,7 @@ import {
 import { DEFAULT_GENERIC_PROVIDER_SETTINGS, openChatPanel } from './test-utils';
 
 const EXPECT_TIMEOUT = 120000;
-const TEST_MIME_BUNDLE_COMMAND_ID = 'jupyterlite-ai-tests:emit-mime-bundle';
+const TEST_MIME_BUNDLE_COMMAND_ID = 'jovia-tests:emit-mime-bundle';
 const BASE_SETTINGS =
   DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model'];
 const PROVIDERS = BASE_SETTINGS.providers.map(provider => {
@@ -43,7 +43,7 @@ test.use({
       defaultProvider: 'generic-functiongemma',
       commandsAutoRenderMimeBundles: [TEST_MIME_BUNDLE_COMMAND_ID],
       systemPrompt:
-        'When asked to execute a command, call execute_command exactly once with this input shape: {"commandId":"jupyterlite-ai-tests:emit-mime-bundle"} and no args. Do not call any other tools and do not ask follow-up questions.'
+        'When asked to execute a command, call execute_command exactly once with this input shape: {"commandId":"jovia-tests:emit-mime-bundle"} and no args. Do not call any other tools and do not ask follow-up questions.'
     }
   }
 });

--- a/ui-tests/tests/skills.spec.ts
+++ b/ui-tests/tests/skills.spec.ts
@@ -9,7 +9,7 @@ import { DEFAULT_GENERIC_PROVIDER_SETTINGS, openChatPanel } from './test-utils';
 const EXPECT_TIMEOUT = 120000;
 const EXPECTED_SKILL_NAME = 'agent-helper';
 const BASE_SETTINGS =
-  DEFAULT_GENERIC_PROVIDER_SETTINGS['@jupyterlite/ai:settings-model'];
+  DEFAULT_GENERIC_PROVIDER_SETTINGS['@jovia/extension:settings-model'];
 const PROVIDERS = BASE_SETTINGS.providers.map(provider => {
   if (provider.id !== 'generic-functiongemma') {
     return provider;
@@ -31,7 +31,7 @@ test.use({
       fetchNews: 'false',
       doNotDisturbMode: true
     },
-    '@jupyterlite/ai:settings-model': {
+    '@jovia/extension:settings-model': {
       ...BASE_SETTINGS,
       providers: PROVIDERS,
       toolsEnabled: true,

--- a/ui-tests/tests/test-utils.ts
+++ b/ui-tests/tests/test-utils.ts
@@ -10,7 +10,7 @@ export const QWEN_MODEL_NAME = 'Qwen2.5';
 export const FUNCTIONGEMMA_MODEL_NAME = 'Functiongemma';
 
 export const DEFAULT_GENERIC_PROVIDER_SETTINGS = {
-  '@jupyterlite/ai:settings-model': {
+  '@jovia/extension:settings-model': {
     defaultProvider: 'generic-qwen',
     mcpServers: [],
     providers: [
@@ -40,7 +40,7 @@ export const TEST_PROVIDERS = [
   { name: 'Generic', settings: DEFAULT_GENERIC_PROVIDER_SETTINGS }
 ];
 
-export const CHAT_PANEL_ID = '@jupyterlite/ai:chat-panel';
+export const CHAT_PANEL_ID = '@jovia/extension:chat-panel';
 
 export const CHAT_PANEL_TITLE = 'Chat with AI assistant';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2192,6 +2192,73 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jovia/extension@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@jovia/extension@workspace:."
+  dependencies:
+    "@ai-sdk/anthropic": ^3.0.58
+    "@ai-sdk/google": ^3.0.43
+    "@ai-sdk/mcp": ^1.0.25
+    "@ai-sdk/mistral": ^3.0.24
+    "@ai-sdk/openai": ^3.0.41
+    "@ai-sdk/openai-compatible": ^2.0.35
+    "@jupyter/chat": ^0.21.1
+    "@jupyterlab/application": ^4.0.0
+    "@jupyterlab/apputils": ^4.5.6
+    "@jupyterlab/builder": ^4.0.0
+    "@jupyterlab/cells": ^4.4.6
+    "@jupyterlab/completer": ^4.0.0
+    "@jupyterlab/coreutils": ^6.4.6
+    "@jupyterlab/docmanager": ^4.4.6
+    "@jupyterlab/docregistry": ^4.4.6
+    "@jupyterlab/filebrowser": ^4.5.6
+    "@jupyterlab/fileeditor": ^4.4.6
+    "@jupyterlab/notebook": ^4.4.6
+    "@jupyterlab/rendermime": ^4.4.6
+    "@jupyterlab/services": ^7.4.6
+    "@jupyterlab/settingregistry": ^4.0.0
+    "@jupyterlab/statusbar": ^4.4.6
+    "@jupyterlab/testutils": ^4.0.0
+    "@jupyterlab/ui-components": ^4.4.6
+    "@lumino/commands": ^2.3.2
+    "@lumino/coreutils": ^2.2.1
+    "@lumino/disposable": ^2.1.4
+    "@lumino/messaging": ^2.0.3
+    "@lumino/polling": ^2.1.4
+    "@lumino/signaling": ^2.1.4
+    "@lumino/widgets": ^2.7.1
+    "@mui/icons-material": ^7
+    "@mui/material": ^7
+    "@types/json-schema": ^7.0.11
+    "@types/node": ^24.3.0
+    "@types/react": ^18.0.26
+    "@types/react-addons-linked-state-mixin": ^0.14.22
+    "@typescript-eslint/eslint-plugin": ^6.1.0
+    "@typescript-eslint/parser": ^6.1.0
+    ai: ^6.0.116
+    css-loader: ^6.7.1
+    eslint: ^8.36.0
+    eslint-config-prettier: ^8.8.0
+    eslint-plugin-prettier: ^5.0.0
+    jupyter-chat-components: ^0.5.0
+    jupyter-secrets-manager: ^0.5.0
+    npm-run-all2: ^7.0.1
+    prettier: ^3.0.0
+    rimraf: ^5.0.1
+    source-map-loader: ^1.0.2
+    style-loader: ^3.3.1
+    stylelint: ^15.10.1
+    stylelint-config-recommended: ^13.0.0
+    stylelint-config-standard: ^34.0.0
+    stylelint-csstree-validator: ^3.0.0
+    stylelint-prettier: ^4.0.0
+    typescript: ~5.8.0
+    yaml: ^2.8.1
+    yjs: ^13.5.0
+    zod: ^4.3.6
+  languageName: unknown
+  linkType: soft
+
 "@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.13
   resolution: "@jridgewell/gen-mapping@npm:0.3.13"
@@ -3026,73 +3093,6 @@ __metadata:
   checksum: 23749d9ba442a49676c95c371c04440b55843d18b121723e170bcb086c4e447d7484745e873cdf47f256e1497304d07370bef875a8c80a5d15bbd5f54c2662a5
   languageName: node
   linkType: hard
-
-"@jupyterlite/ai@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "@jupyterlite/ai@workspace:."
-  dependencies:
-    "@ai-sdk/anthropic": ^3.0.58
-    "@ai-sdk/google": ^3.0.43
-    "@ai-sdk/mcp": ^1.0.25
-    "@ai-sdk/mistral": ^3.0.24
-    "@ai-sdk/openai": ^3.0.41
-    "@ai-sdk/openai-compatible": ^2.0.35
-    "@jupyter/chat": ^0.21.1
-    "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/apputils": ^4.5.6
-    "@jupyterlab/builder": ^4.0.0
-    "@jupyterlab/cells": ^4.4.6
-    "@jupyterlab/completer": ^4.0.0
-    "@jupyterlab/coreutils": ^6.4.6
-    "@jupyterlab/docmanager": ^4.4.6
-    "@jupyterlab/docregistry": ^4.4.6
-    "@jupyterlab/filebrowser": ^4.5.6
-    "@jupyterlab/fileeditor": ^4.4.6
-    "@jupyterlab/notebook": ^4.4.6
-    "@jupyterlab/rendermime": ^4.4.6
-    "@jupyterlab/services": ^7.4.6
-    "@jupyterlab/settingregistry": ^4.0.0
-    "@jupyterlab/statusbar": ^4.4.6
-    "@jupyterlab/testutils": ^4.0.0
-    "@jupyterlab/ui-components": ^4.4.6
-    "@lumino/commands": ^2.3.2
-    "@lumino/coreutils": ^2.2.1
-    "@lumino/disposable": ^2.1.4
-    "@lumino/messaging": ^2.0.3
-    "@lumino/polling": ^2.1.4
-    "@lumino/signaling": ^2.1.4
-    "@lumino/widgets": ^2.7.1
-    "@mui/icons-material": ^7
-    "@mui/material": ^7
-    "@types/json-schema": ^7.0.11
-    "@types/node": ^24.3.0
-    "@types/react": ^18.0.26
-    "@types/react-addons-linked-state-mixin": ^0.14.22
-    "@typescript-eslint/eslint-plugin": ^6.1.0
-    "@typescript-eslint/parser": ^6.1.0
-    ai: ^6.0.116
-    css-loader: ^6.7.1
-    eslint: ^8.36.0
-    eslint-config-prettier: ^8.8.0
-    eslint-plugin-prettier: ^5.0.0
-    jupyter-chat-components: ^0.5.0
-    jupyter-secrets-manager: ^0.5.0
-    npm-run-all2: ^7.0.1
-    prettier: ^3.0.0
-    rimraf: ^5.0.1
-    source-map-loader: ^1.0.2
-    style-loader: ^3.3.1
-    stylelint: ^15.10.1
-    stylelint-config-recommended: ^13.0.0
-    stylelint-config-standard: ^34.0.0
-    stylelint-csstree-validator: ^3.0.0
-    stylelint-prettier: ^4.0.0
-    typescript: ~5.8.0
-    yaml: ^2.8.1
-    yjs: ^13.5.0
-    zod: ^4.3.6
-  languageName: unknown
-  linkType: soft
 
 "@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.0.2, @lezer/common@npm:^1.1.0, @lezer/common@npm:^1.2.0, @lezer/common@npm:^1.2.1":
   version: 1.2.3


### PR DESCRIPTION
Rename the project to `jovia` for the Python package, and `@jovia/extension` for the javascript package.
Using an org for the javascript package (`@jovia`) allows to split the repo into a monorepo later (e.g. extracting the agent).

Related to https://github.com/jupyterlite/ai/issues/297