### PR TITLE
Update links to the any-llm-gateway (now called otari)

### DIFF
--- a/docs/any-llm-gateway.md
+++ b/docs/any-llm-gateway.md
@@ -1,57 +1,78 @@
-# Using any-llm-gateway
+# Using the Otari gateway
 
-[any-llm-gateway](https://otari.ai/docs/gateway) is an OpenAI-compatible proxy server that provides production-grade cost controls, budget management, and usage tracking across multiple LLM providers (OpenAI, Anthropic, Google, etc.).
+[Otari](https://otari.ai/docs/gateway) is an OpenAI-compatible LLM gateway from Mozilla AI (powered by [any-llm](https://github.com/mozilla-ai/any-llm)) that provides API key management, budget enforcement, and usage tracking across multiple LLM providers (OpenAI, Anthropic, Google, etc.). You can run it yourself and point jupyterlite-ai at it as a generic OpenAI-compatible provider.
 
-## Setting up any-llm-gateway
+## Setting up Otari
 
-1. **Installation:** Install and configure the gateway following the [Quick Start guide](https://otari.ai/docs/quickstart). This involves creating a directory, downloading the `docker-compose.yml`, and setting up your `config.yml`.
+1. **Installation:** Install and run the gateway following the [Quick Start guide](https://otari.ai/docs/quickstart). The quickest path is Docker Compose, which starts the gateway together with its PostgreSQL database:
 
-2. Generate a master key:
+```bash
+cp config.example.yml config.yml
+docker compose up -d
+```
+
+See the [deployment guide](https://otari.ai/docs/gateway/deployment) for other options (running from source or using the published Docker image).
+
+2. **Generate a master key** for the management endpoints:
 
 ```bash
 python -c "import secrets; print(secrets.token_urlsafe(32))"
 ```
 
-3. **Configuration:** Configure your providers in `config.yml` with your API keys and model pricing.
+3. **Configuration:** In `config.yml`, set the `master_key`, configure your providers with their API keys, and define pricing for the models you plan to use:
 
-4. Start the gateway: Navigate you your gateway directory and run:
+```yaml
+master_key: 'your-secret-master-key'
 
-```bash
-docker compose up -d
+providers:
+  openai:
+    api_key: 'sk-...'
+  anthropic:
+    api_key: 'sk-ant-...'
+
+pricing:
+  'openai:gpt-4o':
+    input_price_per_million: 2.5
+    output_price_per_million: 10.0
 ```
 
-5. Verify the gateway is running:
+4. **Verify the gateway is running:**
 
 ```bash
 curl http://localhost:8000/health
-# Expected: {"status": "healthy"}
 ```
 
-## Configuring jupyterlite-ai to use any-llm-gateway
+The interactive API docs are also served at `http://localhost:8000/docs`.
+
+:::{important}
+Otari is **fail-closed on pricing** by default (`require_pricing: true`): a request for a model with no pricing entry is rejected with HTTP 402. Add a pricing entry for each model you use, or set `require_pricing: false` to serve unpriced models without cost tracking. See the [pricing](https://otari.ai/docs/guides/pricing) and [configuration](https://otari.ai/docs/gateway/configuration) guides.
+:::
+
+## Configuring jupyterlite-ai to use Otari
 
 Configure the [Generic provider (OpenAI-compatible)](./usage.md#using-a-generic-openai-compatible-provider) with the following settings:
 
 - **Base URL**: `http://localhost:8000/v1` (or your gateway server URL)
-- **Model**: The model name with provider prefix (e.g., `openai:gpt-4`, `anthropic:claude-sonnet-4-5-20250929`)
-- **API Key**: Your gateway virtual API key
+- **Model**: the model name with its provider prefix (e.g., `openai:gpt-4o`, `anthropic:claude-sonnet-4-5-20250929`)
+- **API Key**: an Otari API key (see below)
 
 :::{tip}
-**Using virtual API keys**: The master key requires a `user` field in each request, which the generic OpenAI provider doesn't send by default. To use the gateway seamlessly with jupyterlite-ai, create a virtual API key:
+**Getting an API key**: Otari can bootstrap a first-use API key on startup (printed in the gateway logs) when none exists. To create a named, dedicated key, use your master key to mint a virtual API key:
 
 ```bash
 curl -X POST http://localhost:8000/v1/keys \
-  -H "Authorization: Bearer ${GATEWAY_MASTER_KEY}" \
+  -H "Authorization: Bearer ${OTARI_MASTER_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"key_name": "jupyterlite-ai"}'
 ```
 
-The response will contain a key starting with `gw-`. Use this virtual key as your API key in jupyterlite-ai. Virtual keys automatically track usage without requiring the `user` field.
+The response contains a key starting with `gw-`. Use it as your API key in jupyterlite-ai. Spend is automatically attributed to that key's own user, so usage and budgets are tracked without the generic OpenAI provider needing to send a `user` field.
 :::
 
 :::{note}
-any-llm-gateway uses the `provider:model` format for model names (e.g., `openai:gpt-4`). Check your gateway configuration for available models.
+Otari uses the `provider:model` format for model names (e.g., `openai:gpt-4o`). Available models come from your configured pricing entries — list them with `GET /v1/models` or check your `config.yml`.
 :::
 
 :::{note}
-For more information about any-llm-gateway configuration, including budget management and virtual API keys, see the [any-llm-gateway documentation](https://otari.ai/docs).
+For more about Otari — including budgets, virtual API keys, and deployment — see the [Otari documentation](https://otari.ai/docs).
 :::

--- a/docs/any-llm-gateway.md
+++ b/docs/any-llm-gateway.md
@@ -1,78 +1,22 @@
 # Using the Otari gateway
 
-[Otari](https://otari.ai/docs/gateway) is an OpenAI-compatible LLM gateway from Mozilla AI (powered by [any-llm](https://github.com/mozilla-ai/any-llm)) that provides API key management, budget enforcement, and usage tracking across multiple LLM providers (OpenAI, Anthropic, Google, etc.). You can run it yourself and point jupyterlite-ai at it as a generic OpenAI-compatible provider.
+[Otari](https://otari.ai/docs) is an OpenAI-compatible LLM gateway from Mozilla AI (powered by [any-llm](https://github.com/mozilla-ai/any-llm)) that provides API key management, budget enforcement, and usage tracking across multiple LLM providers (OpenAI, Anthropic, Google, etc.). You can run it yourself and point jupyterlite-ai at it as a generic OpenAI-compatible provider.
 
 ## Setting up Otari
 
-1. **Installation:** Install and run the gateway following the [Quick Start guide](https://otari.ai/docs/quickstart). The quickest path is Docker Compose, which starts the gateway together with its PostgreSQL database:
+Install and run the gateway by following the [Otari Quick Start guide](https://otari.ai/docs/quickstart). Once it is running, take note of:
 
-```bash
-cp config.example.yml config.yml
-docker compose up -d
-```
-
-See the [deployment guide](https://otari.ai/docs/gateway/deployment) for other options (running from source or using the published Docker image).
-
-2. **Generate a master key** for the management endpoints:
-
-```bash
-python -c "import secrets; print(secrets.token_urlsafe(32))"
-```
-
-3. **Configuration:** In `config.yml`, set the `master_key`, configure your providers with their API keys, and define pricing for the models you plan to use:
-
-```yaml
-master_key: 'your-secret-master-key'
-
-providers:
-  openai:
-    api_key: 'sk-...'
-  anthropic:
-    api_key: 'sk-ant-...'
-
-pricing:
-  'openai:gpt-4o':
-    input_price_per_million: 2.5
-    output_price_per_million: 10.0
-```
-
-4. **Verify the gateway is running:**
-
-```bash
-curl http://localhost:8000/health
-```
-
-The interactive API docs are also served at `http://localhost:8000/docs`.
-
-:::{important}
-Otari is **fail-closed on pricing** by default (`require_pricing: true`): a request for a model with no pricing entry is rejected with HTTP 402. Add a pricing entry for each model you use, or set `require_pricing: false` to serve unpriced models without cost tracking. See the [pricing](https://otari.ai/docs/guides/pricing) and [configuration](https://otari.ai/docs/gateway/configuration) guides.
-:::
+- the gateway URL (e.g. `http://localhost:8000`)
+- an Otari API key (see the [Otari documentation](https://otari.ai/docs) for creating one)
 
 ## Configuring jupyterlite-ai to use Otari
 
 Configure the [Generic provider (OpenAI-compatible)](./usage.md#using-a-generic-openai-compatible-provider) with the following settings:
 
 - **Base URL**: `http://localhost:8000/v1` (or your gateway server URL)
-- **Model**: the model name with its provider prefix (e.g., `openai:gpt-4o`, `anthropic:claude-sonnet-4-5-20250929`)
-- **API Key**: an Otari API key (see below)
-
-:::{tip}
-**Getting an API key**: Otari can bootstrap a first-use API key on startup (printed in the gateway logs) when none exists. To create a named, dedicated key, use your master key to mint a virtual API key:
-
-```bash
-curl -X POST http://localhost:8000/v1/keys \
-  -H "Authorization: Bearer ${OTARI_MASTER_KEY}" \
-  -H "Content-Type: application/json" \
-  -d '{"key_name": "jupyterlite-ai"}'
-```
-
-The response contains a key starting with `gw-`. Use it as your API key in jupyterlite-ai. Spend is automatically attributed to that key's own user, so usage and budgets are tracked without the generic OpenAI provider needing to send a `user` field.
-:::
+- **Model**: the model name with its provider prefix, e.g. `openai:gpt-4o` or `anthropic:claude-sonnet-4-5-20250929`
+- **API Key**: your Otari API key
 
 :::{note}
-Otari uses the `provider:model` format for model names (e.g., `openai:gpt-4o`). Available models come from your configured pricing entries — list them with `GET /v1/models` or check your `config.yml`.
-:::
-
-:::{note}
-For more about Otari — including budgets, virtual API keys, and deployment — see the [Otari documentation](https://otari.ai/docs).
+For more about Otari — including configuration, budgets, API keys, and deployment — see the [Otari documentation](https://otari.ai/docs).
 :::

--- a/docs/any-llm-gateway.md
+++ b/docs/any-llm-gateway.md
@@ -1,10 +1,10 @@
 # Using any-llm-gateway
 
-[any-llm-gateway](https://docs.mozilla.ai/) is an OpenAI-compatible proxy server that provides production-grade cost controls, budget management, and usage tracking across multiple LLM providers (OpenAI, Anthropic, Google, etc.).
+[any-llm-gateway](https://otari.ai/docs/gateway) is an OpenAI-compatible proxy server that provides production-grade cost controls, budget management, and usage tracking across multiple LLM providers (OpenAI, Anthropic, Google, etc.).
 
 ## Setting up any-llm-gateway
 
-1. **Installation:** Install and configure the gateway following the [Quick Start guide](https://docs.mozilla.ai/quickstart). This involves creating a directory, downloading the `docker-compose.yml`, and setting up your `config.yml`.
+1. **Installation:** Install and configure the gateway following the [Quick Start guide](https://otari.ai/docs/quickstart). This involves creating a directory, downloading the `docker-compose.yml`, and setting up your `config.yml`.
 
 2. Generate a master key:
 
@@ -53,5 +53,5 @@ any-llm-gateway uses the `provider:model` format for model names (e.g., `openai:
 :::
 
 :::{note}
-For more information about any-llm-gateway configuration, including budget management and virtual API keys, see the [any-llm-gateway documentation](https://docs.mozilla.ai/).
+For more information about any-llm-gateway configuration, including budget management and virtual API keys, see the [any-llm-gateway documentation](https://otari.ai/docs).
 :::

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,7 +31,7 @@ See the dedicated pages for specific providers:
 
 - [Using Ollama](./ollama.md)
 - [Using LiteLLM Proxy](./litellm.md)
-- [Using any-llm-gateway](./any-llm-gateway.md)
+- [Using the Otari gateway](./any-llm-gateway.md)
 - [Web Retrieval tools](./web-retrieval.md)
 
 ## Controlling MIME auto-rendering in chat


### PR DESCRIPTION
Looks like the `any-llm-gateway` moved to the Otari project: https://blog.mozilla.ai/otari-own-your-ai-stack/

This should help fix the failing check links check on CI.

New documentation: https://jupyterlite-ai--345.org.readthedocs.build/en/345/any-llm-gateway/