### PR TITLE
Enable prompt caching for Anthropic models

### DIFF
--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -58,6 +58,9 @@ The provider configuration object requires the following properties:
 - `defaultModels`: Array of model names to show in the settings
 - `modelInfo` (optional): Per-model metadata such as `contextWindow`
 - `supportsBaseURL`: Whether the provider supports a custom base URL
+- `cacheProviderOptions` (optional): Provider-specific options applied to the
+  cacheable prompt message and tool definitions, for providers that support
+  prompt caching
 - `factory`: Function that creates and returns a language model (the registry automatically wraps it for chat usage)
 
 ## Hiding the Built-In Settings UI

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -898,6 +898,9 @@ ${richOutputWorkflowInstruction}`;
       tools,
       temperature,
       maxOutputTokens,
+      prepareStep: ({ messages, model }) => ({
+        messages: Private.addCacheControlToMessages(messages, model)
+      }),
       stopWhen: stepCountIs(maxTurns)
     });
   }
@@ -1303,6 +1306,40 @@ WEB RETRIEVAL POLICY:
 }
 
 namespace Private {
+  /**
+   * Add an Anthropic prompt cache breakpoint to the last message.
+   */
+  export const addCacheControlToMessages = (
+    messages: ModelMessage[],
+    model: LanguageModel
+  ): ModelMessage[] => {
+    if (
+      messages.length === 0 ||
+      !(
+        (typeof model === 'string' &&
+          (model.includes('anthropic') || model.includes('claude'))) ||
+        (typeof model !== 'string' &&
+          (model.provider.includes('anthropic') ||
+            model.modelId.includes('anthropic') ||
+            model.modelId.includes('claude')))
+      )
+    ) {
+      return messages;
+    }
+
+    return messages.map((message, index) =>
+      index === messages.length - 1
+        ? {
+            ...message,
+            providerOptions: {
+              ...message.providerOptions,
+              anthropic: { cacheControl: { type: 'ephemeral' } }
+            }
+          }
+        : message
+    );
+  };
+
   /**
    * Sanitize the messages before adding them to the history.
    *

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -294,6 +294,7 @@ const DEFAULT_MAX_TURNS = 25;
  */
 interface IAgentConfig {
   model: LanguageModel;
+  providerInfo?: IProviderInfo | null;
   tools: ToolMap;
   temperature: number;
   maxOutputTokens?: number;
@@ -824,6 +825,7 @@ export class AgentManager implements IAgentManager {
 
     this._agentConfig = {
       model,
+      providerInfo: activeProviderInfo,
       tools,
       temperature,
       maxOutputTokens: maxTokens,
@@ -867,6 +869,7 @@ export class AgentManager implements IAgentManager {
 
     const {
       model,
+      providerInfo,
       tools,
       temperature,
       maxOutputTokens,
@@ -874,9 +877,14 @@ export class AgentManager implements IAgentManager {
       baseSystemPrompt,
       shouldUseTools
     } = this._agentConfig;
+    const toolsWithCacheProviderOptions =
+      Private.addCacheProviderOptionsToTools(tools, providerInfo);
 
     const baseInstructions = shouldUseTools
-      ? this._getEnhancedSystemPrompt(baseSystemPrompt, tools)
+      ? this._getEnhancedSystemPrompt(
+          baseSystemPrompt,
+          toolsWithCacheProviderOptions
+        )
       : baseSystemPrompt || 'You are a helpful assistant.';
     const richOutputWorkflowInstruction = shouldUseTools
       ? '- When the user asks for visual or rich outputs, prefer running code/commands that produce those outputs and describe that they will be rendered in chat.'
@@ -895,11 +903,14 @@ ${richOutputWorkflowInstruction}`;
     this._agent = new ToolLoopAgent({
       model,
       instructions,
-      tools,
+      tools: toolsWithCacheProviderOptions,
       temperature,
       maxOutputTokens,
-      prepareStep: ({ messages, model }) => ({
-        messages: Private.addCacheControlToMessages(messages, model)
+      prepareStep: ({ messages }) => ({
+        messages: Private.addCacheProviderOptionsToMessages(
+          messages,
+          providerInfo
+        )
       }),
       stopWhen: stepCountIs(maxTurns)
     });
@@ -1306,24 +1317,67 @@ WEB RETRIEVAL POLICY:
 }
 
 namespace Private {
+  type ProviderOptions = NonNullable<ModelMessage['providerOptions']>;
+
   /**
-   * Add an Anthropic prompt cache breakpoint to the last message.
+   * Merge provider options by provider key, preserving provider-specific fields.
    */
-  export const addCacheControlToMessages = (
+  const mergeProviderOptions = (
+    ...providerOptionsList: Array<ModelMessage['providerOptions'] | undefined>
+  ): ModelMessage['providerOptions'] => {
+    const merged: ProviderOptions = {};
+
+    for (const providerOptions of providerOptionsList) {
+      if (!providerOptions) {
+        continue;
+      }
+
+      for (const [provider, options] of Object.entries(providerOptions)) {
+        merged[provider] = {
+          ...(merged[provider] ?? {}),
+          ...options
+        };
+      }
+    }
+
+    return Object.keys(merged).length > 0 ? merged : undefined;
+  };
+
+  /**
+   * Add provider cache options to runtime tool definitions.
+   */
+  export const addCacheProviderOptionsToTools = (
+    tools: ToolMap,
+    providerInfo?: IProviderInfo | null
+  ): ToolMap => {
+    const cacheProviderOptions = providerInfo?.cacheProviderOptions;
+    if (!cacheProviderOptions || Object.keys(tools).length === 0) {
+      return tools;
+    }
+
+    return Object.fromEntries(
+      Object.entries(tools).map(([name, tool]) => [
+        name,
+        {
+          ...tool,
+          providerOptions: mergeProviderOptions(
+            cacheProviderOptions,
+            tool.providerOptions
+          )
+        }
+      ])
+    );
+  };
+
+  /**
+   * Add provider cache options to the last message.
+   */
+  export const addCacheProviderOptionsToMessages = (
     messages: ModelMessage[],
-    model: LanguageModel
+    providerInfo?: IProviderInfo | null
   ): ModelMessage[] => {
-    if (
-      messages.length === 0 ||
-      !(
-        (typeof model === 'string' &&
-          (model.includes('anthropic') || model.includes('claude'))) ||
-        (typeof model !== 'string' &&
-          (model.provider.includes('anthropic') ||
-            model.modelId.includes('anthropic') ||
-            model.modelId.includes('claude')))
-      )
-    ) {
+    const cacheProviderOptions = providerInfo?.cacheProviderOptions;
+    if (messages.length === 0 || !cacheProviderOptions) {
       return messages;
     }
 
@@ -1331,10 +1385,10 @@ namespace Private {
       index === messages.length - 1
         ? {
             ...message,
-            providerOptions: {
-              ...message.providerOptions,
-              anthropic: { cacheControl: { type: 'ephemeral' } }
-            }
+            providerOptions: mergeProviderOptions(
+              cacheProviderOptions,
+              message.providerOptions
+            )
           }
         : message
     );

--- a/src/providers/built-in-providers.ts
+++ b/src/providers/built-in-providers.ts
@@ -38,6 +38,9 @@ export const anthropicProvider: IProviderInfo = {
     webSearch: { implementation: 'anthropic' },
     webFetch: { implementation: 'anthropic' }
   },
+  cacheProviderOptions: {
+    anthropic: { cacheControl: { type: 'ephemeral' } }
+  },
   factory: (options: IModelOptions) => {
     if (!options.apiKey) {
       throw new Error('API key required for Anthropic');

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -283,6 +283,11 @@ export interface IProviderInfo {
   providerToolCapabilities?: IProviderToolCapabilities;
 
   /**
+   * Optional provider-specific options to apply to cacheable prompts and tools.
+   */
+  cacheProviderOptions?: NonNullable<ModelMessage['providerOptions']>;
+
+  /**
    * Factory function for creating language models
    */
   factory: IProviderFactory;


### PR DESCRIPTION
Closes #332 

Adds Anthropic prompt caching by marking the latest conversation message with an ephemeral cache breakpoint. Messages for non-Anthropic models remain unchanged.