### PR TITLE
Make oversized chat prompts recoverable and add context usage warning

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -631,19 +631,13 @@ export class AgentManager implements IAgentManager {
       this._history.push(...Private.sanitizeModelMessages(responseHistory));
     } catch (error) {
       if ((error as Error).name !== 'AbortError') {
-        let helpMessage = `${(error as Error).message}`;
+        const payloadRejectionError = Private.getPayloadRejectionError(error);
+        let helpMessage = `${(payloadRejectionError ?? (error as Error)).message}`;
 
         // Remove attachments from history on payload rejection errors
-        if (
-          APICallError.isInstance(error) &&
-          (error.statusCode === 400 ||
-            error.statusCode === 404 ||
-            error.statusCode === 413 ||
-            error.statusCode === 415 ||
-            error.statusCode === 422)
-        ) {
+        if (payloadRejectionError) {
           this._stripAttachments(
-            [...this._history, ...responseHistory],
+            this._history,
             '_Attachment removed due to error_'
           );
           helpMessage +=
@@ -652,11 +646,6 @@ export class AgentManager implements IAgentManager {
         this._agentEvent.emit({
           type: 'error',
           data: { error: new Error(helpMessage) }
-        });
-        this._history.push(...Private.sanitizeModelMessages(responseHistory));
-        this._history.push({
-          role: 'assistant',
-          content: helpMessage
         });
       }
     } finally {
@@ -1303,6 +1292,32 @@ WEB RETRIEVAL POLICY:
 }
 
 namespace Private {
+  const payloadRejectionStatusCodes = new Set([400, 404, 413, 415, 422]);
+
+  /**
+   * Finds API errors that indicate the request payload was rejected.
+   */
+  export const getPayloadRejectionError = (
+    error: unknown
+  ): APICallError | null => {
+    const seen = new Set<unknown>();
+    let current = error;
+
+    while (current && typeof current === 'object' && !seen.has(current)) {
+      if (
+        APICallError.isInstance(current) &&
+        current.statusCode !== undefined &&
+        payloadRejectionStatusCodes.has(current.statusCode)
+      ) {
+        return current;
+      }
+      seen.add(current);
+      current = (current as { cause?: unknown }).cause;
+    }
+
+    return null;
+  };
+
   /**
    * Sanitize the messages before adding them to the history.
    *

--- a/src/chat-model.ts
+++ b/src/chat-model.ts
@@ -384,6 +384,72 @@ export class AIChatModel extends AbstractChatModel implements IAIChatModel {
   }
 
   /**
+   * Updates a user message and restarts the conversation from that point.
+   */
+  async updateMessage(id: string, message: IMessageContent): Promise<boolean> {
+    if (this._isBusy) {
+      return false;
+    }
+
+    const index = this.messages.findIndex(msg => msg.id === id);
+    if (index === -1) {
+      return false;
+    }
+
+    const original = this.messages[index];
+    if (original.sender.username !== this.user.username) {
+      return false;
+    }
+
+    this._isBusy = true;
+    this._messageQueue = [];
+    this._queueMessageId = null;
+    this._currentStreamingMessage = null;
+    this._toolContexts.clear();
+
+    const editedMessage: IMessageContent = {
+      ...message,
+      id,
+      sender: this.user || original.sender,
+      time: Date.now() / 1000,
+      type: message.type ?? 'msg',
+      raw_time: false,
+      edited: true
+    };
+
+    this.messagesDeleted(index, this.messages.length - index);
+
+    try {
+      await this._rebuildHistory();
+    } catch (error) {
+      await this._agentManager.clearHistory();
+      this._isBusy = false;
+      this.updateWriters([]);
+      this.messageAdded({
+        body: '',
+        mime_model: {
+          data: {
+            'application/vnd.jupyter.chat.components': 'error'
+          },
+          metadata: {
+            errorMessage: `Error restarting conversation: ${(error as Error).message}`
+          }
+        },
+        sender: this._getAIUser(),
+        id: UUID.uuid4(),
+        time: Date.now() / 1000,
+        type: 'msg',
+        raw_time: false
+      });
+      return false;
+    }
+
+    this.messageAdded(editedMessage);
+    await this._processMessage(editedMessage);
+    return true;
+  }
+
+  /**
    * Internal method to process attachments and send the message to the agent.
    */
   private async _processMessage(userMessage: IMessageContent): Promise<void> {

--- a/src/components/context-warning.ts
+++ b/src/components/context-warning.ts
@@ -1,0 +1,179 @@
+import type { TranslationBundle } from '@jupyterlab/translation';
+import { closeIcon } from '@jupyterlab/ui-components';
+import type { ISignal } from '@lumino/signaling';
+
+import type { IAISettingsModel, ITokenUsage } from '../tokens';
+
+const WARNING_THRESHOLD = 95;
+const INPUT_CONTAINER_CLASS = 'jp-chat-input-container';
+const WARNING_CLASS = 'jp-ai-ContextWarning';
+const WARNING_MESSAGE_CLASS = 'jp-ai-ContextWarning-message';
+const WARNING_CLOSE_CLASS = 'jp-ai-ContextWarning-close';
+
+/**
+ * Displays a context usage warning above the chat input.
+ */
+export class ContextWarningController {
+  constructor(options: ContextWarningController.IOptions) {
+    this._host = options.host;
+    this._tokenUsageChanged = options.tokenUsageChanged;
+    this._settingsModel = options.settingsModel;
+    this._trans = options.translator;
+    this._tokenUsage = options.initialTokenUsage;
+    this._threshold = options.threshold ?? WARNING_THRESHOLD;
+
+    this._node = document.createElement('div');
+    this._node.className = WARNING_CLASS;
+    this._node.hidden = true;
+    this._node.setAttribute('role', 'status');
+
+    this._messageNode = document.createElement('span');
+    this._messageNode.className = WARNING_MESSAGE_CLASS;
+    this._node.appendChild(this._messageNode);
+
+    this._closeButton = document.createElement('button');
+    this._closeButton.type = 'button';
+    this._closeButton.className = WARNING_CLOSE_CLASS;
+    this._closeButton.title = this._trans.__('Dismiss context warning');
+    this._closeButton.setAttribute(
+      'aria-label',
+      this._trans.__('Dismiss context warning')
+    );
+    this._closeButton.appendChild(
+      closeIcon.element({
+        elementPosition: 'center',
+        height: '16px',
+        tag: 'span',
+        width: '16px'
+      })
+    );
+    this._closeButton.addEventListener('click', this._dismiss);
+    this._node.appendChild(this._closeButton);
+
+    this._tokenUsageChanged.connect(this._onTokenUsageChanged, this);
+    this._settingsModel.stateChanged.connect(this._onSettingsChanged, this);
+
+    this._observer = new MutationObserver(this._attach);
+    this._observer.observe(this._host, { childList: true, subtree: true });
+
+    this._attach();
+    this._update();
+  }
+
+  dispose(): void {
+    this._observer.disconnect();
+    this._tokenUsageChanged.disconnect(this._onTokenUsageChanged, this);
+    this._settingsModel.stateChanged.disconnect(this._onSettingsChanged, this);
+    this._closeButton.removeEventListener('click', this._dismiss);
+    this._node.remove();
+  }
+
+  private _attach = (): void => {
+    const input = this._host.querySelector(`.${INPUT_CONTAINER_CLASS}`);
+    if (
+      !input?.parentElement ||
+      this._node.parentElement === input.parentElement
+    ) {
+      return;
+    }
+    input.parentElement.insertBefore(this._node, input);
+  };
+
+  private _onTokenUsageChanged = (
+    _: unknown,
+    tokenUsage: ITokenUsage
+  ): void => {
+    this._tokenUsage = tokenUsage;
+    this._update();
+  };
+
+  private _onSettingsChanged = (): void => {
+    this._update();
+  };
+
+  private _dismiss = (): void => {
+    this._dismissedWarningKey = this._warningKey;
+    this._node.hidden = true;
+  };
+
+  private _update(): void {
+    const contextWindow = this._tokenUsage?.contextWindow;
+    const inputTokens = this._tokenUsage?.lastRequestInputTokens;
+    if (
+      inputTokens === undefined ||
+      contextWindow === undefined ||
+      contextWindow <= 0
+    ) {
+      this._node.hidden = true;
+      return;
+    }
+
+    const percent = (inputTokens / contextWindow) * 100;
+    if (percent < this._threshold) {
+      this._node.hidden = true;
+      return;
+    }
+
+    const warningKey = `${inputTokens}:${contextWindow}`;
+    this._warningKey = warningKey;
+    if (warningKey === this._dismissedWarningKey) {
+      this._node.hidden = true;
+      return;
+    }
+
+    const roundedPercent = Math.round(percent).toLocaleString();
+    const message = this._trans.__(
+      'Context warning: last request used %1% of the context window (%2 / %3 tokens).',
+      roundedPercent,
+      inputTokens.toLocaleString(),
+      contextWindow.toLocaleString()
+    );
+
+    this._messageNode.textContent = message;
+    this._node.title = message;
+    this._node.hidden = false;
+    this._attach();
+  }
+
+  private _host: HTMLElement;
+  private _node: HTMLDivElement;
+  private _messageNode: HTMLSpanElement;
+  private _closeButton: HTMLButtonElement;
+  private _observer: MutationObserver;
+  private _tokenUsage: ITokenUsage | undefined;
+  private _threshold: number;
+  private _warningKey: string | undefined;
+  private _dismissedWarningKey: string | undefined;
+  private _tokenUsageChanged: ISignal<unknown, ITokenUsage>;
+  private _settingsModel: IAISettingsModel;
+  private _trans: TranslationBundle;
+}
+
+export namespace ContextWarningController {
+  export interface IOptions {
+    /**
+     * The chat widget host node.
+     */
+    host: HTMLElement;
+    /**
+     * The token usage changed signal.
+     */
+    tokenUsageChanged: ISignal<unknown, ITokenUsage>;
+    /**
+     * The settings model.
+     */
+    settingsModel: IAISettingsModel;
+    /**
+     * Initial token usage.
+     */
+    initialTokenUsage?: ITokenUsage;
+    /**
+     * The application language translator.
+     */
+    translator: TranslationBundle;
+    /**
+     * Warning threshold as a percentage.
+     */
+    threshold?: number;
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './clear-button';
 export * from './completion-status';
+export * from './context-warning';
 export * from './model-select';
 export * from './stop-button';
 export * from './usage-display';

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,8 @@ import {
   createToolSelectItem,
   stopItem,
   CompletionStatusWidget,
-  UsageWidget
+  UsageWidget,
+  ContextWarningController
 } from './components';
 
 import { AISettingsModel } from './models/settings-model';
@@ -563,6 +564,14 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
       });
       chatPanel.current?.toolbar.insertBefore('markRead', 'usage', usageWidget);
 
+      const contextWarning = new ContextWarningController({
+        host: widget.node,
+        tokenUsageChanged: model.tokenUsageChanged,
+        settingsModel,
+        initialTokenUsage: model.agentManager.tokenUsage,
+        translator: trans
+      });
+
       if (model.saveAvailable) {
         const saveChatButton = new SaveComponentWidget({
           model,
@@ -605,6 +614,7 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
         model.writersChanged?.disconnect(writersChanged);
 
         // Dispose of the approval buttons widget when the chat is disposed.
+        contextWarning.dispose();
         outputAreaCompat.dispose();
       });
     });

--- a/src/widgets/main-area-chat.ts
+++ b/src/widgets/main-area-chat.ts
@@ -6,6 +6,7 @@ import { CommandRegistry } from '@lumino/commands';
 
 import { SaveComponentWidget } from '../components/save-button';
 import { UsageWidget } from '../components/usage-display';
+import { ContextWarningController } from '../components/context-warning';
 import { RenderedMessageOutputAreaCompat } from '../rendered-message-outputarea';
 import { CommandIds, IAIChatModel, type IAISettingsModel } from '../tokens';
 
@@ -62,6 +63,14 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
     });
     this.toolbar.addItem('usage', usageWidget);
 
+    this._contextWarning = new ContextWarningController({
+      host: this.content.node,
+      tokenUsageChanged: this.model.tokenUsageChanged,
+      settingsModel: options.settingsModel,
+      initialTokenUsage: this.model.agentManager.tokenUsage,
+      translator: trans
+    });
+
     // Temporary compat: keep output-area CSS context for MIME renderers
     // until jupyter-chat provides it natively.
     this._outputAreaCompat = new RenderedMessageOutputAreaCompat({
@@ -77,6 +86,7 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
     super.dispose();
     // Dispose of the approval buttons widget when the chat is disposed.
     this._outputAreaCompat.dispose();
+    this._contextWarning.dispose();
     this.model.writersChanged?.disconnect(this._writersChanged);
     this.model.titleChanged.disconnect(this._titleChanged);
   }
@@ -113,4 +123,5 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
   };
 
   private _outputAreaCompat: RenderedMessageOutputAreaCompat;
+  private _contextWarning: ContextWarningController;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -109,6 +109,49 @@
   padding: 0 0.4em;
 }
 
+.jp-ai-ContextWarning {
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0 17px 6px;
+  padding: 6px 8px;
+  border: 1px solid var(--jp-warn-color2);
+  border-left-width: 3px;
+  border-radius: 4px;
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  line-height: 1.4;
+}
+
+.jp-ai-ContextWarning[hidden] {
+  display: none;
+}
+
+.jp-ai-ContextWarning-message {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.jp-ai-ContextWarning-close {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--jp-ui-font-color2);
+  cursor: pointer;
+}
+
+.jp-ai-ContextWarning-close:hover {
+  color: var(--jp-ui-font-color1);
+}
+
 /* Save button */
 .jp-ai-SaveButton {
   display: flex;


### PR DESCRIPTION
Closes #291 

This change makes oversized provider prompt errors non-blocking by avoiding persistence of failed turns while still cleaning rejected attachment history. It also supports editing a previous user message to restart the conversation from that point, and adds a dismissible context warning above the chat input when the last request reaches 95% of the model context window.

