### PR TITLE
Make use of chat toolbar items

### DIFF
--- a/src/components/save-button.tsx
+++ b/src/components/save-button.tsx
@@ -31,8 +31,12 @@ export interface ISaveButtonProps {
  * When auto-save is active, the save button displays the JupyterLab
  * toggled-on appearance (inset box-shadow all around).
  */
-export function SaveComponent(props: ISaveButtonProps): JSX.Element {
+export function SaveComponent(props: ISaveButtonProps): JSX.Element | null {
   const { model, translator: trans } = props;
+
+  if (!model.saveAvailable) {
+    return null;
+  }
 
   const [autosave, setAutosave] = useState(model.autosave);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -464,6 +464,11 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
       before: 'markRead'
     };
 
+    const chatToolbarItems: MultiChatPanel.IChatToolbarItem[] = [
+      usageWidgetItem,
+      saveChatWidgetItem
+    ];
+
     // Create chat panel with drag/drop functionality
     const chatPanel = new MultiChatPanel({
       rmRegistry,
@@ -508,7 +513,7 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
           area: 'main',
           name
         }) as Promise<boolean>,
-      chatToolbarItems: [usageWidgetItem, saveChatWidgetItem]
+      chatToolbarItems: chatToolbarItems
     });
 
     chatPanel.id = '@jupyterlite/ai:chat-panel';
@@ -654,6 +659,7 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
       tracker,
       modelHandler,
       trans,
+      chatToolbarItems,
       themeManager,
       labShell,
       palette,
@@ -737,6 +743,7 @@ function registerCommands(
   tracker: WidgetTracker<MainAreaChat | ChatWidget>,
   modelRegistry: IChatModelHandler,
   trans: TranslationBundle,
+  chatToolbarItems: MultiChatPanel.IChatToolbarItem[],
   themeManager?: IThemeManager,
   labShell?: ILabShell,
   palette?: ICommandPalette,
@@ -809,7 +816,8 @@ function registerCommands(
         content,
         commands,
         settingsModel,
-        trans
+        trans,
+        chatToolbarItems
       });
       app.shell.add(widget, 'main');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,6 +438,32 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
     const namespace = 'ai-chat';
     const tracker = new WidgetTracker<MainAreaChat | ChatWidget>({ namespace });
 
+    // The token usage widget.
+    const usageWidgetItem: MultiChatPanel.IChatToolbarItem = {
+      name: 'usage',
+      create: (widget: ChatWidget) => {
+        const model = widget.model as IAIChatModel;
+        return new UsageWidget({
+          tokenUsageChanged: model.tokenUsageChanged,
+          settingsModel,
+          initialTokenUsage: model.agentManager.tokenUsage,
+          translator: trans
+        });
+      },
+      before: 'markRead'
+    };
+
+    // The save chat widget.
+    const saveChatWidgetItem: MultiChatPanel.IChatToolbarItem = {
+      name: 'saveChat',
+      create: (widget: ChatWidget) =>
+        new SaveComponentWidget({
+          model: widget.model as IAIChatModel,
+          translator: trans
+        }),
+      before: 'markRead'
+    };
+
     // Create chat panel with drag/drop functionality
     const chatPanel = new MultiChatPanel({
       rmRegistry,
@@ -481,7 +507,8 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
         app.commands.execute(CommandIds.moveChat, {
           area: 'main',
           name
-        }) as Promise<boolean>
+        }) as Promise<boolean>,
+      chatToolbarItems: [usageWidgetItem, saveChatWidgetItem]
     });
 
     chatPanel.id = '@jupyterlite/ai:chat-panel';
@@ -523,7 +550,6 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
       chatPanel.disposed.connect(disconnectSettingsButtonListener);
     }
 
-    let usageWidget: UsageWidget | null = null;
     chatPanel.chatOpened.connect((_, widget) => {
       const model = widget.model as IAIChatModel;
 
@@ -551,30 +577,6 @@ const plugin: JupyterFrontEndPlugin<IChatTracker> = {
 
       // Update the tracker if the active provider changed.
       model.agentManager.activeProviderChanged.connect(saveTracker);
-
-      // Update the token usage widget.
-      usageWidget?.dispose();
-
-      usageWidget = new UsageWidget({
-        tokenUsageChanged: model.tokenUsageChanged,
-        settingsModel,
-        initialTokenUsage: model.agentManager.tokenUsage,
-        translator: trans
-      });
-      chatPanel.current?.toolbar.insertBefore('markRead', 'usage', usageWidget);
-
-      if (model.saveAvailable) {
-        const saveChatButton = new SaveComponentWidget({
-          model,
-          translator: trans
-        });
-
-        chatPanel.current?.toolbar.insertAfter(
-          'markRead',
-          'saveChat',
-          saveChatButton
-        );
-      }
 
       // Listen for writers change to display the stop button.
       function writersChanged(_: IChatModel, writers: IChatModel.IWriter[]) {

--- a/src/widgets/main-area-chat.ts
+++ b/src/widgets/main-area-chat.ts
@@ -1,11 +1,9 @@
-import { ChatWidget, IChatModel } from '@jupyter/chat';
+import { ChatWidget, IChatModel, MultiChatPanel } from '@jupyter/chat';
 import { CommandToolbarButton, MainAreaWidget } from '@jupyterlab/apputils';
 import { launchIcon } from '@jupyterlab/ui-components';
 import type { TranslationBundle } from '@jupyterlab/translation';
 import { CommandRegistry } from '@lumino/commands';
 
-import { SaveComponentWidget } from '../components/save-button';
-import { UsageWidget } from '../components/usage-display';
 import { RenderedMessageOutputAreaCompat } from '../rendered-message-outputarea';
 import { CommandIds, IAIChatModel, type IAISettingsModel } from '../tokens';
 
@@ -14,6 +12,7 @@ export namespace MainAreaChat {
     commands: CommandRegistry;
     settingsModel: IAISettingsModel;
     trans: TranslationBundle;
+    chatToolbarItems?: MultiChatPanel.IChatToolbarItem[];
   }
 }
 
@@ -25,8 +24,6 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
     super(options);
     this.title.label = this.model.name;
     this.title.caption = this.model.title ?? this.model.name;
-
-    const { trans } = options;
 
     // Move to side button.
     this.toolbar.addItem(
@@ -42,25 +39,11 @@ export class MainAreaChat extends MainAreaWidget<ChatWidget> {
       })
     );
 
-    if (this.model.saveAvailable) {
-      // Save chat component
-      this.toolbar.addItem(
-        'saveChat',
-        new SaveComponentWidget({
-          model: this.model,
-          translator: trans
-        })
-      );
+    if (options.chatToolbarItems) {
+      for (const item of options.chatToolbarItems) {
+        this.toolbar.addItem(item.name, item.create(this.content));
+      }
     }
-
-    // Add the token usage button.
-    const usageWidget = new UsageWidget({
-      tokenUsageChanged: this.model.tokenUsageChanged,
-      settingsModel: options.settingsModel,
-      initialTokenUsage: this.model.agentManager.tokenUsage,
-      translator: trans
-    });
-    this.toolbar.addItem('usage', usageWidget);
 
     // Temporary compat: keep output-area CSS context for MIME renderers
     // until jupyter-chat provides it natively.


### PR DESCRIPTION
This PR avoid duplicating toolbar items between the side panel chats and the main area chats.

It needs to wait for https://github.com/jupyterlab/jupyter-chat/pull/445 to be released.