### PR TITLE
Bump to @jupyter/chat 0.24 stable

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -43,7 +43,7 @@
     "watch:labextension": "jupyter-builder watch ."
   },
   "dependencies": {
-    "@jupyter/chat": "^0.24.0-alpha.0",
+    "@jupyter/chat": "^0.24.0",
     "@jupyterlab/application": "^4.5.8",
     "@jupyterlab/apputils": "^4.6.8",
     "@jupyterlab/coreutils": "^6.5.8",

--- a/packages/persona/package.json
+++ b/packages/persona/package.json
@@ -43,7 +43,7 @@
     "watch:labextension": "jupyter-builder watch ."
   },
   "dependencies": {
-    "@jupyter/chat": "^0.24.0-alpha.0",
+    "@jupyter/chat": "^0.24.0",
     "@jupyter/ydoc": "^4.0.0",
     "@jupyterlab/application": "^4.5.8",
     "@jupyterlab/apputils": "^4.6.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,9 +2327,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter/chat@npm:^0.24.0-alpha.0":
-  version: 0.24.0-alpha.0
-  resolution: "@jupyter/chat@npm:0.24.0-alpha.0"
+"@jupyter/chat@npm:^0.24.0":
+  version: 0.24.0
+  resolution: "@jupyter/chat@npm:0.24.0"
   dependencies:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
@@ -2360,7 +2360,7 @@ __metadata:
     clsx: ^2.1.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 458807a4e339f127b5088088af6d748928ba922d91207766c1aac2e1644fc53c42a300e14844e04a52582bda3aa08ebb84ef5065b90f2f58a02f8aa1f39feb2b
+  checksum: 679d0429b2b993321712f8024c19cf817cca0f23f916047d10e7fe517f1cd09ea68dac3b34fdbf1443978be25712314530495ed392306f5263f9e71ca8f1c9ba
   languageName: node
   linkType: hard
 
@@ -3140,7 +3140,7 @@ __metadata:
   resolution: "@jupyterlite/ai@workspace:packages/ai"
   dependencies:
     "@jupyter/builder": ^1.0.2
-    "@jupyter/chat": ^0.24.0-alpha.0
+    "@jupyter/chat": ^0.24.0
     "@jupyterlab/application": ^4.5.8
     "@jupyterlab/apputils": ^4.6.8
     "@jupyterlab/coreutils": ^6.5.8
@@ -3214,7 +3214,7 @@ __metadata:
   resolution: "@jupyternaut/persona@workspace:packages/persona"
   dependencies:
     "@jupyter/builder": ^1.0.2
-    "@jupyter/chat": ^0.24.0-alpha.0
+    "@jupyter/chat": ^0.24.0
     "@jupyter/ydoc": ^4.0.0
     "@jupyterlab/application": ^4.5.8
     "@jupyterlab/apputils": ^4.6.8


### PR DESCRIPTION
Using the stable version of `@jupyter/chat` 0.24.0